### PR TITLE
Make columns space-filling again

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -43,7 +43,7 @@ export default class App {
 
   async build() {
     await this.buildStartSelection(select('#startSelection'));
-
+    this.attachListener();
   }
 
   private async buildStartSelection(elem: d3.Selection<any>) {
@@ -85,6 +85,24 @@ export default class App {
     this.showSelection();
   }
 
+  private attachListener() {
+    const debounce = (fn, delay) => {
+      let delayed;
+
+      return function(e) {
+        clearTimeout(delayed);
+        delayed = setTimeout(function() {
+          fn(e);
+        }, delay);
+      };
+    };
+
+    window.addEventListener('resize', debounce(() => {
+      if(this.manager) {
+        this.manager.relayout();
+      }
+    }, 300));
+  }
 
   private findType(data: IMotherTableType, currentIDType: string) {
     const coltype = data.desc.coltype;

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -22,6 +22,8 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
 
   minimumWidth: number = 10;
   preferredWidth: number = 100;
+  lockedWidth: number = -1;
+
   dataView: IDataType;
   sortCriteria: string = SORT.asc;
 
@@ -111,29 +113,14 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
     if ($lockButton.classed('fa-lock')) {
       // UNLOCKING
       $lockButton.attr('class', 'fa fa-unlock');
+      this.lockedWidth = -1;
       this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'unlocked');
-
-      this.$node
-        .classed('itemWidth', true)
-        .classed('itemFixedWidth', false)
-        .style('flex', `1 1 ${this.$node.property('clientWidth')}px`)
-        //.style('width', `${this.$node.property('clientWidth')}px`)
-        .style('min-width', `${this.minimumWidth}px`)
-        .style('max-width', `${this.preferredWidth}px`);
 
     } else {
       // LOCKING
       $lockButton.attr('class', 'fa fa-lock');
+      this.lockedWidth = this.$node.property('clientWidth');
       this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'locked');
-
-      this.$node
-        .classed('itemFixedWidth', true)
-        .classed('itemWidth', false)
-        .style('flex', `0 0 ${this.$node.property('clientWidth')}px`);
-        //.style('width', null)
-        //.style('min-width', `${this.currentWidth}px`)
-        //.style('min-width', null)
-        //.style('max-width', `${this.currentWidth}px`);
     }
   }
 

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -20,8 +20,8 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
 
   $node:d3.Selection<any>;
 
-  minimumWidth: number = 10;
-  preferredWidth: number = 100;
+  minWidth: number = 10;
+  maxWidth: number = 100;
   lockedWidth: number = -1;
 
   dataView: IDataType;
@@ -69,8 +69,8 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
       .append('li')
       .classed('column', true)
       .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
-      .style('min-width', this.minimumWidth + 'px')
-      .style('width', this.preferredWidth + 'px')
+      .style('min-width', this.minWidth + 'px')
+      .style('width', this.maxWidth + 'px')
       .html(`
         <header class="columnHeader">
           <div class="toolbar"></div>

--- a/src/column/CategoricalColumn.ts
+++ b/src/column/CategoricalColumn.ts
@@ -10,8 +10,8 @@ import {mixin} from 'phovea_core/src/index';
 
 export default class CategoricalColumn extends AVectorColumn<string, ICategoricalVector> {
 
-  minimumWidth: number = 30;
-  preferredWidth: number = 200; //80
+  minWidth: number = 30;
+  maxWidth: number = 200; //80
 
   constructor(data: ICategoricalVector, orientation: EOrientation, parent: HTMLElement) {
     super(data, orientation);

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -250,17 +250,14 @@ export default class ColumnManager extends EventHandler {
     // try to distribute the container width equally between all columns
     const avgWidth = totalAvailableWidth / (this.columns.length - lockedWidthCols.length - minWidthCols.length);
 
-    //console.group('width');
     // use avgWidth if minimumWidth < avgWidth < preferredWidth otherwise use minimumWidth or preferredWidth
     const colWidths = this.columns.map((col) => {
       if(col.lockedWidth > 0) {
         return  col.lockedWidth;
       }
-      //console.log('width', Math.max(col.minimumWidth, Math.min(col.preferredWidth, avgWidth)), 'avgWidth', avgWidth, 'minWidth', col.minimumWidth, 'prefWidth', col.preferredWidth);
       // use avgWidth if minimumWidth < avgWidth < preferredWidth otherwise use minimumWidth or preferredWidth
       return Math.max(col.minimumWidth, Math.min(col.preferredWidth, avgWidth));
     });
-    //console.groupEnd();
 
     return colWidths;
   }

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -241,8 +241,8 @@ export default class ColumnManager extends EventHandler {
 
     // sum the width of all columns that have already the minWidth
     const minWidthCols = this.columns
-      .filter((d) => d.$node.property('clientWidth') === d.minimumWidth)
-      .map((d) => d.minimumWidth);
+      .filter((d) => d.$node.property('clientWidth') === d.minWidth)
+      .map((d) => d.minWidth);
     const sumMinWidth = minWidthCols.reduce((acc, val) => acc + val, 0);
 
     const totalAvailableWidth = this.node.clientWidth - sumLockedWidth - sumMinWidth;
@@ -256,7 +256,7 @@ export default class ColumnManager extends EventHandler {
         return  col.lockedWidth;
       }
       // use avgWidth if minimumWidth < avgWidth < preferredWidth otherwise use minimumWidth or preferredWidth
-      return Math.max(col.minimumWidth, Math.min(col.preferredWidth, avgWidth));
+      return Math.max(col.minWidth, Math.min(col.maxWidth, avgWidth));
     });
 
     return colWidths;

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -78,7 +78,7 @@ export default class ColumnManager extends EventHandler {
       this.rangeNow = await data.ids();
 
     }
-    await col.update((this.rangeNow));
+    await col.update(this.rangeNow);
 
     col.on(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
     col.on(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this.updatePrimarySortByCol.bind(this));
@@ -87,30 +87,9 @@ export default class ColumnManager extends EventHandler {
     this.columns.push(col);
     this.columnsHierarchy = this.columns;
     this.updateSort(null);
-    const managerWidth = this.node.clientWidth;
-    const panel = this.currentWidth(this.columns);
-
-    //if (managerWidth - panel < 0) {
-    //console.log("Need relayout");
-    //} else {
-    //console.log("Enough space");
-    //}
-
-    //console.log("col manager width: " + managerWidth);
-    //console.log("panel width: " + panel);
 
     this.fire(ColumnManager.EVENT_COLUMN_ADDED, col);
-    return this.relayout();
-
-  }
-
-  currentWidth(columns:AnyColumn[]) {
-    let currentPanelWidth: number = 0;
-    columns.forEach((col, index) => {
-      //console.log("column no."+ index + "width: " + col.node.clientWidth);
-      currentPanelWidth = col.$node.property('clientWidth') + currentPanelWidth;
-    });
-    return currentPanelWidth;
+    //this.relayout();
   }
 
 
@@ -232,21 +211,29 @@ export default class ColumnManager extends EventHandler {
   async relayout() {
     await resolveIn(10);
 
+    // try to distribute the container width equally between all columns
+    const avgWidth = this.node.clientWidth / this.columns.length;
+
+    // use avgWidth if minimumWidth < avgWidth < preferredWidth otherwise use minimumWidth or preferredWidth
+    const colWidths = this.columns.map((col) => Math.max(col.minimumWidth, Math.min(col.preferredWidth, avgWidth)));
 
     const height = Math.min(...this.columns.map((c) => c.$node.property('clientHeight') - c.$node.select('header').property('clientHeight')));
-    // compute margin
+
+    // compute margin for the column stratifications (from @mijar)
     const verticalMargin = this.columns.reduce((prev, c) => {
       const act = c.getVerticalMargin();
       return {top: Math.max(prev.top, act.top), bottom: Math.max(prev.bottom, act.bottom)};
     }, {top: 0, bottom: 0});
 
-    this.columns.forEach((col) => {
+    this.columns.forEach((col, i) => {
       const margin = col.getVerticalMargin();
-      //console.log(margin,verticalMargin)
       col.$node.style('margin-top', (verticalMargin.top - margin.top) + 'px');
       col.$node.style('margin-bottom', (verticalMargin.bottom - margin.bottom) + 'px');
 
-      col.layout(col.body.property('clientWidth'), height);
+      // use avgWidth if minimumWidth < avgWidth < preferredWidth otherwise use minimumWidth or preferredWidth
+      col.$node.style('width', colWidths[i] + 'px');
+
+      col.layout(colWidths[i], height);
     });
   }
 }

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -17,8 +17,8 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
   static readonly EVENT_DATA_REMOVED = 'removedData';
   static readonly EVENT_COLUMN_ADDED = 'added';
 
-  minimumWidth: number = 150;
-  preferredWidth: number = 300;
+  minWidth: number = 150;
+  maxWidth: number = 300;
 
   private multiform: MultiForm;
   private rowRange: Range;

--- a/src/column/NumberColumn.ts
+++ b/src/column/NumberColumn.ts
@@ -11,8 +11,8 @@ import NumberFilter from '../filter/NumberFilter';
 import {NUMERICAL_COLOR_MAP} from './utils';
 
 export default class NumberColumn extends AVectorColumn<number, INumericalVector> {
-  minimumWidth: number = 30;
-  preferredWidth: number = 200;
+  minWidth: number = 30;
+  maxWidth: number = 200;
 
   constructor(data: INumericalVector, orientation: EOrientation, parent: HTMLElement) {
     super(data, orientation);

--- a/src/column/StringColumn.ts
+++ b/src/column/StringColumn.ts
@@ -8,8 +8,8 @@ import {mixin} from 'phovea_core/src/index';
 import {IMultiFormOptions} from 'phovea_core/src/multiform';
 
 export default class StringColumn extends AVectorColumn<string, IStringVector> {
-  minimumWidth: number = 80;
-  preferredWidth: number = 300;
+  minWidth: number = 80;
+  maxWidth: number = 300;
 
   constructor(data: IStringVector, orientation: EOrientation, parent: HTMLElement) {
     super(data, orientation);


### PR DESCRIPTION
See #196 and #172

![taggle_space-filling-columns](https://cloud.githubusercontent.com/assets/5851088/23677298/db84a75a-037f-11e7-9f42-b6b62276ec6e.gif)

The algorithm so far:
* Sum the the width of locked columns
* Sum the width of columns that have already the minimum width
* Substract both sums from the available width of the container 
* Devide by the number of columns left -> new width
* Set width columns that are flexible (not locked):
  * If new width > max width -> max width
  * If new width < max width -> new width
  * If new width < minimum width -> minimum width

There is still a bug with a wrong x-scale of the multiform visualization (see https://github.com/Caleydo/mothertable/issues/198)