### PR TITLE
Bugfix for duplicating vis when building state from URL hash

### DIFF
--- a/src/SupportView.ts
+++ b/src/SupportView.ts
@@ -3,7 +3,6 @@
  */
 
 import IDType from 'phovea_core/src/idtype/IDType';
-import {ICategoricalVector, INumericalVector} from 'phovea_core/src/vector';
 import {
   VALUE_TYPE_STRING, VALUE_TYPE_CATEGORICAL, VALUE_TYPE_INT, VALUE_TYPE_REAL,
   IDataType
@@ -17,7 +16,6 @@ import {IFilterAbleType} from 'mothertable/src/filter/FilterManager';
 import {AnyColumn} from './column/ColumnManager';
 import {hash} from 'phovea_core/src/index';
 import AColumn from './column/AColumn';
-import {IAnyMatrix} from 'phovea_core/src/matrix/IMatrix';
 
 
 export default class SupportView extends EventHandler {

--- a/src/SupportView.ts
+++ b/src/SupportView.ts
@@ -17,6 +17,7 @@ import {IFilterAbleType} from 'mothertable/src/filter/FilterManager';
 import {AnyColumn} from './column/ColumnManager';
 import {hash} from 'phovea_core/src/index';
 import AColumn from './column/AColumn';
+import {IAnyMatrix} from 'phovea_core/src/matrix/IMatrix';
 
 
 export default class SupportView extends EventHandler {
@@ -29,7 +30,7 @@ export default class SupportView extends EventHandler {
   node: HTMLElement;
 
   private filterManager: FilterManager;
-  private _matrixData;
+  private _matrixData: Map<string, INumericalMatrix> = new Map();
   private datasets: IDataType[];
 
   constructor(public readonly idType: IDType, parent: HTMLElement, public readonly id?: string) {
@@ -96,8 +97,13 @@ export default class SupportView extends EventHandler {
     this.filterManager.primarySortColumn(sortColdata);
   }
 
-  get matrixData() {
-    return this._matrixData;
+  /**
+   * Returns the matrix data for a given dataset id
+   * @param datasetId
+   * @returns {undefined|INumericalMatrix}
+   */
+  getMatrixData(datasetId:string):INumericalMatrix {
+    return this._matrixData.get(datasetId);
   }
 
   public remove(data: IDataType) {
@@ -183,7 +189,7 @@ export default class SupportView extends EventHandler {
       this.filterManager.push(<IFilterAbleType>data);
     }
     if(data.desc.type === AColumn.DATATYPE.matrix) {
-      this._matrixData = data;
+      this._matrixData.set(data.desc.id, <INumericalMatrix>data);
     }
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import {IAnyVector} from 'phovea_core/src/vector';
 import {randomId} from 'phovea_core/src/index';
 import Range from 'phovea_core/src/range/Range';
 import {hash} from 'phovea_core/src/index';
+import {IDataType} from 'phovea_core/src/datatype';
 
 /**
  * The main class for the App app
@@ -167,7 +168,7 @@ export default class App {
         if (data.desc.type === AColumn.DATATYPE.matrix) {
           const otherIdtype: IDType = this.findType(data, idtype.id);
           this.triggerMatrix();
-          this.newSupportManger(otherIdtype);
+          this.newSupportManger(data, otherIdtype);
         }
 
         return promise;
@@ -223,7 +224,7 @@ export default class App {
   }
 
 
-  private newSupportManger(otherIdtype: IDType) {
+  private newSupportManger(data: IDataType, otherIdtype: IDType) {
 
     // this.newManager = new ColumnManager(otherIdtype, EOrientation.Horizontal, <HTMLElement>this.node.querySelector('main'));
 
@@ -232,7 +233,7 @@ export default class App {
     const matrixSupportView = new SupportView(otherIdtype, node, id);
     this.supportView.push(matrixSupportView);
 
-    const m = this.supportView[0].matrixData;
+    const m = this.supportView[0].getMatrixData(data.desc.id);
     const matrixnode = <HTMLElement>node.querySelector(`.${otherIdtype.id}.filter-manager`);
     // d3.select(node).select(`.${otherIdtype.id}.filter-manager`);
     new MatrixFilter(m.t, matrixnode);

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -70,6 +70,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
 
 
   async updateMatrixCol(colRange) {
+    // override in MatrixColumn
     return colRange;
   }
 
@@ -119,6 +120,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   }
 
   async updateMultiForms(rowRanges: Range[]) {
+    // hook
   }
 
   protected lockColumnWidth($lockButton) {

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -85,18 +85,19 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
 
   }
 
-  async updateMultiForms(idRanges) {
+  async updateMultiForms(idRanges: Range[]) {
+    const v: any = await this.data.data(); // wait first for data and then continue with removing old forms
     this.updateSortIcon();
     this.body.selectAll('.multiformList').remove();
     this.multiformList = [];
-    const v: any = await this.data.data();
     const domain = d3.extent(v);
     for (const r of idRanges) {
       const multiformdivs = this.body.append('div').classed('multiformList', true);
       const $header = multiformdivs.append('div').classed('vislist', true);
-      this.body.selectAll('.multiformList').on('mouseover', function () {
-        d3.select(this).select('.vislist').style('display', 'block');
-      })
+      this.body.selectAll('.multiformList')
+        .on('mouseover', function () {
+          d3.select(this).select('.vislist').style('display', 'block');
+        })
         .on('mouseleave', function () {
           d3.select(this).select('.vislist').style('display', 'none');
         });

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -16,7 +16,6 @@ import * as d3 from 'd3';
 export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
   static readonly EVENT_COLUMN_REMOVED = 'removed';
   static readonly EVENT_DATA_REMOVED = 'removedData';
-  static readonly EVENT_COLUMN_ADDED = 'added';
 
   minWidth: number = 150;
   maxWidth: number = 300;
@@ -149,7 +148,6 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
     const col = createColumn(data, this.orientation, <HTMLElement>this.$node.node());
     col.on(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
     this.columns.push(col);
-    this.fire(MatrixColumn.EVENT_COLUMN_ADDED, col);
     this.relayout();
   }
 


### PR DESCRIPTION
Please confirm if this fixes the problem -- at least in my tests it is working as expected.

![taggle_reload-from-hash](https://cloud.githubusercontent.com/assets/5851088/24000961/0fbea5f0-0a5d-11e7-8505-71390a1232b3.gif)

**Explanation**
While waiting for some results from `await` the columns have been changed and thus used a wrong number of columns when splitting the multiforms. I tried to avoid using the class variable `this.filterHiearchy`. Instead I sliced a copy so that I can ensure the elements (https://github.com/Caleydo/mothertable/compare/thinkh/bugfix-loading-from-hash?expand=1#diff-5af33055eeb4b6024eada05612cd2bceR158) and passed these columns directly from function to function.