### PR TITLE
Column stratification (#43)

### DIFF
--- a/src/SortHandler/SortHandler.ts
+++ b/src/SortHandler/SortHandler.ts
@@ -2,14 +2,12 @@
  * Created by bikramkawan on 11/02/2017.
  */
 
-import {EventHandler} from 'phovea_core/src/event';
 import {
   VALUE_TYPE_STRING, VALUE_TYPE_CATEGORICAL, VALUE_TYPE_INT, VALUE_TYPE_REAL,
   IDataType
 } from 'phovea_core/src/datatype';
 import {IAnyVector} from 'phovea_core/src/vector';
 import Range from 'phovea_core/src/range/Range';
-import {AnyColumn} from '../column/ColumnManager';
 
 
 export const SORT = {
@@ -19,12 +17,11 @@ export const SORT = {
 };
 
 
-export default class SortEventHandler extends EventHandler {
+export default class SortHandler {
 
   private sortCriteria: string;
 
   constructor() {
-    super();
     //this.sortCriteria = sortCriteria;
     //this.sortMe();
   }
@@ -71,6 +68,9 @@ export default class SortEventHandler extends EventHandler {
    * @returns {Promise<Range[][]>}
    */
   async sortColumns(columns): Promise<Range[][]> {
+    if(columns.length === 0) {
+      return [[]];
+    }
     const d = await columns[0].data.idView(columns[0].rangeView);
     let range: any = [await d.ids()];
     const initialColType = columns[0].data.desc.value.type;

--- a/src/SupportView.ts
+++ b/src/SupportView.ts
@@ -78,6 +78,7 @@ export default class SupportView extends EventHandler {
   private async loadDatasets() {
     this.datasets = convertTableToVectors(await listData())
       .filter((d) => d.idtypes.indexOf(this.idType) >= 0 && isPossibleDataset(d));
+
     if (this.idType.id !== 'artist' && this.idType.id !== 'country') {
       const vectorsOnly = this.datasets.filter((d) => d.desc.type === AColumn.DATATYPE.vector);
       if (vectorsOnly.length > 0) {

--- a/src/SupportView.ts
+++ b/src/SupportView.ts
@@ -19,6 +19,11 @@ import {hash} from 'phovea_core/src/index';
 import AColumn from './column/AColumn';
 
 
+export interface IFuelBarDataSize {
+  total: number;
+  filtered: number;
+}
+
 export default class SupportView extends EventHandler {
 
   static EVENT_DATASETS_ADDED = 'datasetAdded';
@@ -27,6 +32,7 @@ export default class SupportView extends EventHandler {
   private static readonly HASH_FILTER_DELIMITER = ',';
 
   $node: d3.Selection<any>;
+  private $fuelBar: d3.Selection<any>;
 
   private filterManager: FilterManager;
   private _matrixData: Map<string, INumericalMatrix> = new Map();
@@ -35,16 +41,33 @@ export default class SupportView extends EventHandler {
   constructor(public readonly idType: IDType, $parent: d3.Selection<any>, public readonly id: number) {
     super();
     this.build($parent);
+    this.init();
   }
 
   private get idTypeHash() {
     return this.idType.id + '_' + this.id;
   }
 
-  private async build($parent) {
-    this.$node = $parent.append('div')
-      .classed(this.idType.id, true);
+  private build($parent) {
+    const $wrapper = $parent.append('div')
+      .classed(`support-view-${this.idType.id}`, true)
+      .classed(`support-view`, true);
 
+    $wrapper.append('h1')
+      .classed('idType', true)
+      .html(this.idType.id.toUpperCase());
+
+    this.$fuelBar = $wrapper.append('div')
+      .classed(`dataPreview-${this.idType.id}`, true)
+      .classed(`fuelBar`, true);
+
+    this.$fuelBar.append('div').classed('totalData', true);
+    this.$fuelBar.append('div').classed('filteredData', true);
+
+    this.$node = $wrapper.append('div').classed(this.idType.id, true);
+  }
+
+  private async init() {
     this.setupFilterManager();
 
     await this.loadDatasets();
@@ -205,6 +228,16 @@ export default class SupportView extends EventHandler {
     if(data.desc.type === AColumn.DATATYPE.matrix) {
       this._matrixData.set(data.desc.id, <INumericalMatrix>data);
     }
+  }
+
+  public updateFuelBar(dataSize:IFuelBarDataSize) {
+    const availableWidth = parseFloat(this.$fuelBar.style('width'));
+    const total = (dataSize.total);
+    const filtered = (dataSize.filtered) || 0;
+    const totalWidth = availableWidth / total * filtered;
+
+    this.$fuelBar.select('.totalData').style('width', `${totalWidth}px`);
+    this.$fuelBar.select('.filteredData').style('width', `${availableWidth - totalWidth}px`);
   }
 
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -173,7 +173,7 @@ export default class App {
           return columns;
         })
         .then(() => {
-          this.colManager.updateSort();
+          this.colManager.updateColumns();
         });
     });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -224,7 +224,9 @@ export default class App {
       // ... when all stratifications are pushed -> render the column and relayout
       Promise.all(promises)
         .then(() => {
-          col.updateMultiForms();
+          return Promise.all([col.updateColStrats(), col.updateMultiForms()]);
+        })
+        .then(() => {
           this.colManager.relayout();
         });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import {hash} from 'phovea_core/src/index';
 import {IDataType} from 'phovea_core/src/datatype';
 import {IFuelBarDataSize} from './SupportView';
 import Range1D from 'phovea_core/src/range/Range1D';
+import {AnyFilter} from './filter/AFilter';
 
 /**
  * The main class for the App app
@@ -145,7 +146,7 @@ export default class App {
 
     this.supportView.push(supportView);
 
-    supportView.on(FilterManager.EVENT_SORT_DRAGGING, (evt: any, data: AnyColumn[]) => {
+    supportView.on(FilterManager.EVENT_SORT_DRAGGING, (evt: any, data: AnyFilter[]) => {
       this.colManager.mapFiltersAndSort(data);
     });
 
@@ -214,6 +215,10 @@ export default class App {
       this.triggerMatrix(filter, supportView.id);
       this.dataSize.filtered = filter.size()[0];
       supportView.updateFuelBar(this.dataSize);
+    });
+
+    supportView.on(FilterManager.EVENT_SORT_DRAGGING, (evt: any, data: AnyFilter[]) => {
+      col.updateColStratsSorting(data);
     });
 
     // add columns if we add one or multiple datasets

--- a/src/app.ts
+++ b/src/app.ts
@@ -209,7 +209,8 @@ export default class App {
 
     supportView.updateFuelBar(this.dataSize);
 
-    supportView.on(SupportView.EVENT_FILTER_CHANGED, (evt: any, filter: Range1D) => {
+    supportView.on(SupportView.EVENT_FILTER_CHANGED, (evt: any, filter: Range) => {
+      col.filterStratData(filter);
       this.triggerMatrix(filter, supportView.id);
       this.dataSize.filtered = filter.size()[0];
       supportView.updateFuelBar(this.dataSize);

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -92,7 +92,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
       });
 
     $toolbar.append('button')
-      .classed('fa fa-close', true)
+      .classed('fa fa-trash', true)
       .on('click', () => {
         this.fire(AColumn.EVENT_REMOVE_ME);
         return false;

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -7,7 +7,7 @@ import Range1D from 'phovea_core/src/range/Range1D';
 import Range from 'phovea_core/src/range/Range';
 import {EventHandler} from 'phovea_core/src/event';
 import * as d3 from 'd3';
-import {SORT} from '../SortEventHandler/SortEventHandler';
+import {SORT} from '../SortHandler/SortHandler';
 import AVectorFilter from '../filter/AVectorFilter';
 export enum EOrientation {
   Horizontal,
@@ -44,19 +44,45 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   }
 
   get body() {
-    return this.$node.select('main');
+    return this.$node.select(':scope > main'); // :scope = enforce direct children
   }
 
   get header() {
     return this.$node.select('header.columnHeader');
   }
 
-  protected get toolbar() {
-    return this.$node.select('div.toolbar');
+  protected build($parent: d3.Selection<any>): d3.Selection<any> {
+    if(this.orientation === EOrientation.Horizontal) {
+      return this.buildHorizontal($parent);
+    }
+    return this.buildVertical($parent);
   }
 
-  protected build($parent: d3.Selection<any>) {
-    this.$node = $parent.select('.columnList')
+  /**
+   * Add template for stratifications columns (in the header )
+   * @param $parent
+   * @returns {Selection<any>}
+   */
+  protected buildVertical($parent: d3.Selection<any>): d3.Selection<any> {
+    const $node = $parent.insert('li', 'li')
+      .classed('column-strat', true)
+      .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
+      .html(`
+        <header>
+          <span>${this.data.desc.name}</span>
+        </header> 
+        <main></main>
+      `);
+    return $node;
+  }
+
+  /**
+   * Add template for regular columns (in the main view)
+   * @param $parent
+   * @returns {Selection<any>}
+   */
+  protected buildHorizontal($parent: d3.Selection<any>): d3.Selection<any> {
+    const $node = $parent
       .append('li')
       .classed('column', true)
       .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
@@ -70,18 +96,17 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
         </header>
         <main></main>`);
 
-    const header = this.$node.selectAll('header')
+    const header = $node.selectAll('header')
       .on('mouseover', function () {
-        d3.select(this).select('.toolbar').style('display', 'block');
+        $node.select('.toolbar').style('display', 'block');
       })
       .on('mouseleave', function () {
-        d3.select(this).select('.toolbar').style('display', 'none');
+        $node.select('.toolbar').style('display', 'none');
       });
 
-    // this.buildBody(this.body);
-    this.buildToolbar(this.toolbar);
+    this.buildToolbar($node.select('div.toolbar'));
 
-    return this.$node;
+    return $node;
   }
 
   protected buildToolbar($toolbar: d3.Selection<any>) {

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -65,6 +65,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
    */
   protected buildVertical($parent: d3.Selection<any>): d3.Selection<any> {
     const $node = $parent.insert('li', 'li')
+      .datum(this)
       .classed('column-strat', true)
       .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
       .html(`
@@ -84,6 +85,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   protected buildHorizontal($parent: d3.Selection<any>): d3.Selection<any> {
     const $node = $parent
       .append('li')
+      .datum(this)
       .classed('column', true)
       .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
       .style('min-width', this.minWidth + 'px')

--- a/src/column/AColumnManager.ts
+++ b/src/column/AColumnManager.ts
@@ -63,6 +63,16 @@ export default class AColumnManager {
     this.stratifyMatrixCols(rangeListMap);
   }
 
+  filter(range:Range[]) {
+    this.vectorCols.forEach((col) => {
+      col.updateMultiForms(range);
+    });
+    // TODO might be wrong
+    this.matrixCols.forEach((col) => {
+      col.updateMultiForms(range);
+    });
+  }
+
   private stratifyVectorCols(rangeListMap:Map<string, Range[]>) {
     this.vectorCols.forEach((col) => {
       col.updateMultiForms(rangeListMap.get(col.data.desc.id));

--- a/src/column/AColumnManager.ts
+++ b/src/column/AColumnManager.ts
@@ -1,0 +1,88 @@
+/**
+ * Created by Holger Stitz on 17.03.2017.
+ */
+
+import {AnyColumn} from './ColumnManager';
+import AColumn from './AColumn';
+import SortHandler from '../SortHandler/SortHandler';
+import Range from 'phovea_core/src/range/Range';
+
+export default class AColumnManager {
+
+  readonly columns: AnyColumn[] = [];
+
+  constructor() {
+    //
+  }
+
+  get vectorCols():AnyColumn[]  {
+    return this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.vector);
+  }
+
+  get matrixCols():AnyColumn[] {
+    return this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.matrix);
+  }
+
+  /**
+   * Compares columns based on the dataset and returns the first column with that dataset
+   * @param columns
+   */
+  unique(columns):AnyColumn[] {
+    const data = columns.map((d) => d.data.desc.id);
+    return columns.filter((col, pos) => data.indexOf(col.data.desc.id) === pos);
+  }
+
+  add(column: AnyColumn) {
+    this.columns.push(column);
+  }
+
+  remove(column: AnyColumn) {
+    this.columns.splice(this.columns.indexOf(column), 1);
+  }
+
+  async sort():Promise<Map<string, Range[]>>  {
+    const colsWithRange = new Map<string, Range[]>();
+    const uniqueVectorCols = this.unique(this.vectorCols);
+
+    if(uniqueVectorCols.length === 0) {
+      return colsWithRange;
+    }
+
+    // The sort object is created on the fly and destroyed after it exits this method
+    const s = new SortHandler();
+    const rangeList = await s.sortColumns(uniqueVectorCols);
+
+    uniqueVectorCols.forEach((col, index) => {
+      colsWithRange.set(col.data.desc.id, rangeList[index]);
+    });
+    return colsWithRange;
+  }
+
+  async stratify(rangeListMap:Map<string, Range[]>) {
+    this.stratifyVectorCols(rangeListMap);
+    this.stratifyMatrixCols(rangeListMap);
+  }
+
+  private stratifyVectorCols(rangeListMap:Map<string, Range[]>) {
+    this.vectorCols.forEach((col) => {
+      col.updateMultiForms(rangeListMap.get(col.data.desc.id));
+    });
+  }
+
+  private stratifyMatrixCols(rangeListMap:Map<string, Range[]>) {
+    const lastRangeList = this.lastRangeList(rangeListMap);
+    this.matrixCols.forEach((col) => {
+      col.updateMultiForms(lastRangeList);
+    });
+  }
+
+  private lastRangeList(rangeListMap:Map<string, Range[]>) {
+    const uniqueVectorCols = this.unique(this.vectorCols);
+
+    if(uniqueVectorCols.length === 0) {
+      return [];
+    }
+
+    return rangeListMap.get(uniqueVectorCols[uniqueVectorCols.length - 1].data.desc.id);
+  }
+}

--- a/src/column/AColumnManager.ts
+++ b/src/column/AColumnManager.ts
@@ -6,10 +6,11 @@ import {AnyColumn} from './ColumnManager';
 import AColumn from './AColumn';
 import SortHandler from '../SortHandler/SortHandler';
 import Range from 'phovea_core/src/range/Range';
+import {AnyFilter} from '../filter/AFilter';
 
 export default class AColumnManager {
 
-  readonly columns: AnyColumn[] = [];
+  columns: AnyColumn[] = [];
 
   constructor() {
     //
@@ -71,6 +72,10 @@ export default class AColumnManager {
     this.matrixCols.forEach((col) => {
       col.updateMultiForms(range);
     });
+  }
+
+  sortByFilters(filterList:AnyFilter[]) {
+    this.columns = filterList.map((f) => this.columns.filter((c) => c.data === f.data)[0]);
   }
 
   private stratifyVectorCols(rangeListMap:Map<string, Range[]>) {

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -18,7 +18,7 @@ import MatrixColumn from './MatrixColumn';
 import {IEvent, EventHandler} from 'phovea_core/src/event';
 import {resolveIn} from 'phovea_core/src';
 import IDType from 'phovea_core/src/idtype/IDType';
-import SortEventHandler from '../SortEventHandler/SortEventHandler';
+import SortHandler from '../SortHandler/SortHandler';
 import AVectorFilter from '../filter/AVectorFilter';
 import {on} from 'phovea_core/src/event';
 import AFilter from '../filter/AFilter';
@@ -96,7 +96,7 @@ export default class ColumnManager extends EventHandler {
     // if (data.idtypes[0] !== this.idType) {
     //   throw new Error('invalid idtype');
     // }
-    const col = createColumn(data, this.orientation, this.$parent);
+    const col = createColumn(data, this.orientation, this.$node);
 
     if (this.firstColumnRange === undefined) {
       this.firstColumnRange = await data.ids();
@@ -125,7 +125,7 @@ export default class ColumnManager extends EventHandler {
     col.off(AColumn.EVENT_COLUMN_LOCK_CHANGED, this.onLockChange);
     this.fire(ColumnManager.EVENT_COLUMN_REMOVED, col);
     this.fire(ColumnManager.EVENT_DATA_REMOVED, col.data);
-    this.relayout();
+    this.updateColumns();
   }
 
   /**
@@ -194,7 +194,7 @@ export default class ColumnManager extends EventHandler {
     }
 
     // The sort object is created on the fly and destroyed after it exits this method
-    const s = new SortEventHandler();
+    const s = new SortHandler();
     this.rangeList = await s.sortColumns(cols);
 
     cols.forEach((col, index) => {
@@ -371,7 +371,7 @@ export function distributeColWidths(columns: {lockedWidth: number, minWidth: num
 
 export function createColumn(data: IMotherTableType, orientation: EOrientation, $parent: d3.Selection<any>): AnyColumn {
   switch (data.desc.type) {
-    case 'vector':
+    case AColumn.DATATYPE.vector:
       const v = <IStringVector|ICategoricalVector|INumericalVector>data;
       switch (v.desc.value.type) {
         case VALUE_TYPE_STRING:
@@ -384,7 +384,7 @@ export function createColumn(data: IMotherTableType, orientation: EOrientation, 
       }
       throw new Error('invalid vector type');
 
-    case 'matrix':
+    case AColumn.DATATYPE.matrix:
       const m = <INumericalMatrix>data;
       switch (m.desc.value.type) {
         case VALUE_TYPE_INT:

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -237,9 +237,10 @@ export default class ColumnManager extends EventHandler {
    * Calculate the maximum height of all column stratification areas and set it for every column
    */
   private relayoutColStrats() {
-    const $strats = this.$node.selectAll('aside');
+    const $strats = this.$node.selectAll('aside')
+      .style('height', null); // remove height first, to calculate a new one
     const maxHeight = Math.max(...$strats[0].map((d:HTMLElement) => d.clientHeight));
-    $strats.style('height', `${maxHeight}px`);
+    $strats.style('height', maxHeight + 'px');
   }
 
   private async calColHeight(height) {

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -30,6 +30,7 @@ import min = d3.min;
 import {scaleTo} from './utils';
 import {IAnyVector} from 'phovea_core/src/vector/IVector';
 import VisManager from './VisManager';
+import {AnyFilter} from '../filter/AFilter';
 
 export declare type AnyColumn = AColumn<any, IDataType>;
 export declare type IMotherTableType = IStringVector|ICategoricalVector|INumericalVector|INumericalMatrix;
@@ -164,10 +165,10 @@ export default class ColumnManager extends EventHandler {
   }
 
   /**
-   * Find corresponding columns for given list of filters and update the sorted hierarchy
+   * Find corresponding columns for given list of filters and update the sorted  hierarchy
    * @param filterList
    */
-  mapFiltersAndSort(filterList: AnyColumn[]) {
+  mapFiltersAndSort(filterList: AnyFilter[]) {
     this.filtersHierarchy = filterList.map((d) => this.columns.filter((c) => c.data === d.data)[0]);
     this.updateColumns();
   }

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -9,11 +9,11 @@ import {IDataType} from 'phovea_core/src/datatype';
 import Range from 'phovea_core/src/range/Range';
 import {list as rlist} from 'phovea_core/src/range';
 import {scaleTo, NUMERICAL_COLOR_MAP} from './utils';
-import {IEvent} from 'phovea_core/src/event';
 import {createColumn, AnyColumn, IMotherTableType} from './ColumnManager';
 import * as d3 from 'd3';
 import VisManager from './VisManager';
 import AColumnManager from './AColumnManager';
+import Range1D from 'phovea_core/src/range/Range1D';
 
 export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
   minWidth: number = 150;
@@ -109,6 +109,10 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
     const rangeListMap:Map<string, Range[]> = await this.colStratManager.sort();
     console.log(rangeListMap, this.colStratManager.columns); // see output for stratification
     this.colStratManager.stratify(rangeListMap);
+  }
+
+  filterStratData(range: Range) {
+    this.colStratManager.filter([range]);
   }
 
 }

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -40,7 +40,9 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
   protected build($parent: d3.Selection<any>) {
     this.$node = super.build($parent);
 
-    this.$colStrat = this.$node.select('aside');
+    this.$colStrat = this.$node.select('aside')
+      .append('ol')
+      .attr('reversed', 'reversed');
 
     return this.$node;
   }
@@ -55,8 +57,8 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
   }
 
   pushColStratData(data: IMotherTableType) {
-    this.$colStrat.append('div').html(data.desc.name);
-    this.$colStrat.style('height', null);
+    this.$colStrat.insert('li', 'li').html(data.desc.name);
+
     return Promise.resolve;
   }
 

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -107,12 +107,12 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
    */
   async updateColStrats() {
     const rangeListMap:Map<string, Range[]> = await this.colStratManager.sort();
-    console.log(rangeListMap, this.colStratManager.columns); // see output for stratification
-    this.colStratManager.stratify(rangeListMap);
+    //console.log(rangeListMap, this.colStratManager.columns); // see output for stratification
+    //this.colStratManager.stratify(rangeListMap);
   }
 
   filterStratData(range: Range) {
-    this.colStratManager.filter([range]);
+    //this.colStratManager.filter([range]);
   }
 
 }

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -14,6 +14,7 @@ import * as d3 from 'd3';
 import VisManager from './VisManager';
 import AColumnManager from './AColumnManager';
 import Range1D from 'phovea_core/src/range/Range1D';
+import {AnyFilter} from '../filter/AFilter';
 
 export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
   minWidth: number = 150;
@@ -113,6 +114,12 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
 
   filterStratData(range: Range) {
     //this.colStratManager.filter([range]);
+  }
+
+  updateColStratsSorting(filterList: AnyFilter[]) {
+    this.colStratManager.sortByFilters(filterList);
+    this.updateColStrats();
+    // TODO still need to update the DOM order in `this.$colStrat`
   }
 
 }

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -54,7 +54,13 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
     };
   }
 
-  async updateMultiForms(rowRanges:Range[], colRange?:Range) {
+  pushColStratData(data: IMotherTableType) {
+    this.$colStrat.append('div').html(data.desc.name);
+    this.$colStrat.style('height', null);
+    return Promise.resolve;
+  }
+
+  async updateMultiForms(rowRanges?:Range[], colRange?:Range) {
     this.body.selectAll('.multiformList').remove();
     this.multiformList = [];
 

--- a/src/filter/AFilter.ts
+++ b/src/filter/AFilter.ts
@@ -7,6 +7,7 @@ import {EventHandler} from 'phovea_core/src/event';
 import {Range1D} from 'phovea_core/src/range';
 import * as d3 from 'd3';
 
+export declare type AnyFilter = AFilter<any, IDataType>;
 
 abstract class AFilter<T, DATATYPE extends IDataType> extends EventHandler {
   static readonly EVENT_FILTER_CHANGED = 'filterChanged';

--- a/src/filter/AVectorFilter.ts
+++ b/src/filter/AVectorFilter.ts
@@ -5,7 +5,7 @@
 import AFilter from './AFilter';
 import {IVector} from 'phovea_core/src/vector';
 import {IStringValueTypeDesc} from 'phovea_core/src/datatype';
-import {SORT} from '../SortEventHandler/SortEventHandler';
+import {SORT} from '../SortHandler/SortHandler';
 import * as d3 from 'd3';
 import {on, fire} from 'phovea_core/src/event';
 

--- a/src/filter/CategoricalFilter.ts
+++ b/src/filter/CategoricalFilter.ts
@@ -6,7 +6,7 @@ import AVectorFilter from './AVectorFilter';
 import {ICategoricalVector} from 'phovea_core/src/vector';
 import {Range1D} from 'phovea_core/src/range';
 import * as d3 from 'd3';
-import SortEventHandler, {SORT, stringSort} from '../SortEventHandler/SortEventHandler';
+import SortHandler, {SORT, stringSort} from '../SortHandler/SortHandler';
 import {on} from 'phovea_core/src/event';
 
 export default class CategoricalFilter extends AVectorFilter<string, ICategoricalVector> {
@@ -20,22 +20,13 @@ export default class CategoricalFilter extends AVectorFilter<string, ICategorica
     super(data);
     this.$node = this.build($parent);
     on(AVectorFilter.EVENT_SORTBY_FILTER_ICON, this.sortByFilterIcon.bind(this));
-
   }
 
   protected build($parent: d3.Selection<any>) {
     const $node = super.build($parent);
-    // node.innerHTML = `<button>${this.data.desc.name}</button>`;
-    // (<HTMLElement>node.querySelector('button')).addEventListener('click', () => {
-    //
-    //   this.triggerFilterChanged();
-    // });
-
-
     this.generateLabel($node, this.data.desc.name);
     const dispHistogram: boolean = true;
     this.generateCategories($node.select('main'), dispHistogram);
-
     return $node;
   }
 

--- a/src/filter/StringFilter.ts
+++ b/src/filter/StringFilter.ts
@@ -19,16 +19,8 @@ export default class StringFilter extends AVectorFilter<string, IStringVector> {
   protected build($parent: d3.Selection<any>) {
     const $node = super.build($parent);
 
-
     this.generateLabel($node, this.data.desc.name);
     this.generateSearchInput($node.select('main'));
-
-
-    // node.innerHTML = `<button>${this.data.desc.name}</button>`;
-    // (<HTMLElement>node.querySelector('button')).addEventListener('click', () => {
-    //   console.log(this.data)
-    //   this.triggerFilterChanged();
-    // });
 
     return $node;
   }

--- a/src/styles/_columnManager.scss
+++ b/src/styles/_columnManager.scss
@@ -63,6 +63,14 @@
       // height: 600px;
       //align-items: center;
     }
+
+    // column stratification
+    aside {
+      ol, li {
+        list-style-type: decimal;
+        margin: 0;
+      }
+    }
   }
 }
 

--- a/tests/AColumnManager.test.ts
+++ b/tests/AColumnManager.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Created by Holger Stitz on 17.03.2017.
+ */
+
+/// <reference types="jasmine" />
+import * as d3 from 'd3';
+import AColumnManager from '../src/column/AColumnManager';
+import CategoricalColumn from '../src/column/CategoricalColumn';
+import MatrixColumn from '../src/column/MatrixColumn';
+import {EOrientation} from '../src/column/AColumn';
+import {asVector} from 'phovea_core/src/vector/Vector';
+import {IVector} from 'phovea_core/src/vector';
+import {asMatrix} from 'phovea_core/src/matrix/Matrix';
+import {IMatrix} from '../../phovea_core/src/matrix/IMatrix';
+import Range from 'phovea_core/src/range/Range';
+
+describe('AColumnManager', () => {
+
+  const colManager = new AColumnManager();
+
+  const vRows = ['vRow1', 'vRow2', 'vRow3'];
+  const vData = ['value1', 'value2', 'value3'];
+  const vector:IVector<any, any> = asVector(vRows, vData);
+
+  const vectorColumn = new CategoricalColumn(vector, EOrientation.Horizontal, d3.select('#foo'));
+  colManager.add(vectorColumn);
+
+  // add as duplicate with same data
+  const vectorColumnSameData = new CategoricalColumn(vector, EOrientation.Horizontal, d3.select('#foo'));
+  colManager.add(vectorColumnSameData);
+
+  const mRows = ['mRow1', 'mRow2', 'mRow3'];
+  const mCols = ['mCol1', 'mCol2', 'mCol3'];
+  const mData = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
+  const matrix:IMatrix<any, any> = asMatrix(mData, mRows, mCols);
+
+  const matrixColumn = new MatrixColumn(matrix, EOrientation.Horizontal, d3.select('#foo'));
+  colManager.add(matrixColumn);
+
+  it('number of added columns', () => {
+    expect(colManager.columns.length).toEqual(3);
+  });
+
+  it('test column order', () => {
+    expect(colManager.columns[0]).toEqual(vectorColumn);
+    expect(colManager.columns[2]).toEqual(matrixColumn);
+  });
+
+  it('test vector columns', () => {
+    expect(colManager.vectorCols.length).toEqual(2);
+    expect(colManager.vectorCols[0]).toEqual(vectorColumn);
+  });
+
+  it('test matrix columns', () => {
+    expect(colManager.matrixCols.length).toEqual(1);
+    expect(colManager.matrixCols[0]).toEqual(matrixColumn);
+  });
+
+  it('unique columns', () => {
+    expect(colManager.unique(colManager.columns).length).toEqual(2);
+    expect(colManager.unique(colManager.columns)[0]).toEqual(vectorColumn);
+    expect(colManager.unique(colManager.columns)[1]).toEqual(matrixColumn);
+  });
+
+});

--- a/tests/AColumnManager.test.ts
+++ b/tests/AColumnManager.test.ts
@@ -11,8 +11,7 @@ import {EOrientation} from '../src/column/AColumn';
 import {asVector} from 'phovea_core/src/vector/Vector';
 import {IVector} from 'phovea_core/src/vector';
 import {asMatrix} from 'phovea_core/src/matrix/Matrix';
-import {IMatrix} from '../../phovea_core/src/matrix/IMatrix';
-import Range from 'phovea_core/src/range/Range';
+import {IMatrix} from 'phovea_core/src/matrix/IMatrix';
 
 describe('AColumnManager', () => {
 

--- a/tests/sort.test.ts
+++ b/tests/sort.test.ts
@@ -4,7 +4,7 @@
 /// <reference types="jasmine" />
 
 import Range from 'phovea_core/src/range/Range';
-import {SORT, prepareRangeFromList, numSort, stringSort, filterCat} from '../src/SortEventHandler/SortEventHandler';
+import {SORT, prepareRangeFromList, numSort, stringSort, filterCat} from '../src/SortHandler/SortHandler';
 
 
 function makeRangeFromList(arr) {


### PR DESCRIPTION
See #43.

I prepared everything for the columns stratifications. See adding stratifications and filtering in the following screencast:

![taggle_column-stratifications](https://cloud.githubusercontent.com/assets/5851088/24060496/bd408c2e-0b53-11e7-8043-bcdea7409aa0.gif)

**Note:** I deactivated the multiforms at the moment (https://github.com/Caleydo/mothertable/commit/f367f057fc185c2797c82c77b55f7bb0a3dd07cf and https://github.com/Caleydo/mothertable/commit/4d66495d7228a0713c6a00029e2b0689de7ba7b5) , because there are no horizontal implementations of the multiform visualizations. --> See #242

**Notes on the implementation:**
* I extended the Matrix column to hold column stratifications
* Column stratifications are regular columns, but in `EOrientation.Vertical` direction (https://github.com/Caleydo/mothertable/pull/241/files#diff-99a8c04a7d4d1ef691bd9fdae88553f6R99)
* `EOrientation.Vertical` columns use a different column basic template (https://github.com/Caleydo/mothertable/pull/241/files#diff-43ccd23153974bdf8fc9f41f687acc9fR66)
* The sorting and stratifying works identically to the regular columns