### PR TITLE
Icon chooser for aggregated/unaggregated visualizations (#247)

### DIFF
--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -75,7 +75,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
       .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
       .html(`
         <header>
-          <span>${formatAttributeName(this.data.desc.name)}</span>
+          <div class="labelName">${formatAttributeName(this.data.desc.name)}</div>
         </header> 
         <main></main>
       `);
@@ -98,18 +98,10 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
       .html(`
         <aside></aside>
         <header class="columnHeader">
+          <div class="labelName">${formatAttributeName(this.data.desc.name)}</div>
           <div class="toolbar"></div>
-          <span>${formatAttributeName(this.data.desc.name)}</span>
         </header>
         <main></main>`);
-
-    const header = $node.selectAll('header')
-      .on('mouseover', function () {
-        $node.select('.toolbar').style('display', 'block');
-      })
-      .on('mouseleave', function () {
-        $node.select('.toolbar').style('display', 'none');
-      });
 
     this.buildToolbar($node.select('div.toolbar'));
 
@@ -117,14 +109,16 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   }
 
   protected buildToolbar($toolbar: d3.Selection<any>) {
-    const $lockButton = $toolbar.append('button')
-      .classed('fa fa-unlock', true)
+    const $lockButton = $toolbar.append('a')
+      .attr('title', 'Lock column')
+      .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`)
       .on('click', () => {
         this.lockColumnWidth($lockButton);
       });
 
-    $toolbar.append('button')
-      .classed('fa fa-trash', true)
+    $toolbar.append('a')
+      .attr('title', 'Remove column')
+      .html(`<i class="fa fa-trash fa-fw" aria-hidden="true"></i><span class="sr-only">Remove column</span>`)
       .on('click', () => {
         this.fire(AColumn.EVENT_REMOVE_ME);
         return false;
@@ -136,15 +130,21 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   }
 
   protected lockColumnWidth($lockButton) {
-    if ($lockButton.classed('fa-lock')) {
+    if ($lockButton.select('i').classed('fa-lock')) {
       // UNLOCKING
-      $lockButton.attr('class', 'fa fa-unlock');
+      $lockButton
+        .classed('active', false)
+        .attr('title', 'Lock column')
+        .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`);
       this.lockedWidth = -1;
       this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'unlocked');
 
     } else {
       // LOCKING
-      $lockButton.attr('class', 'fa fa-lock');
+      $lockButton
+        .classed('active', true)
+        .attr('title', 'Unlock column')
+        .html(`<i class="fa fa-lock fa-fw" aria-hidden="true"></i><span class="sr-only">Unlock column</span>`);
       this.lockedWidth = this.$node.property('clientWidth');
       this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'locked');
     }

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -10,9 +10,9 @@ import * as d3 from 'd3';
 import {SORT} from '../SortHandler/SortHandler';
 import AVectorFilter from '../filter/AVectorFilter';
 import {formatAttributeName} from './utils';
-import MultiForm from '../../../phovea_core/src/multiform/MultiForm';
-import {IMultiForm} from '../../../phovea_core/src/multiform/IMultiForm';
-import {IVisPluginDesc} from '../../../phovea_core/src/vis';
+import MultiForm from 'phovea_core/src/multiform/MultiForm';
+import {IMultiForm} from 'phovea_core/src/multiform/IMultiForm';
+import {IVisPluginDesc} from 'phovea_core/src/vis';
 import VisManager from './VisManager';
 export enum EOrientation {
   Horizontal,

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -14,9 +14,11 @@ import MultiForm from 'phovea_core/src/multiform/MultiForm';
 export declare type IStringVector = IVector<string, IStringValueTypeDesc>;
 
 export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends AColumn<T, DATATYPE> {
+
+  static readonly EVENT_SORTBY_COLUMN_HEADER = 'sortByMe';
+
   multiform: MultiForm;
   dataView: IDataType;
-  static readonly EVENT_SORTBY_COLUMN_HEADER = 'sortByMe';
   multiformList = [];
 
   constructor(data: DATATYPE, orientation: EOrientation) {
@@ -37,31 +39,38 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
   }
 
   protected buildToolbar($toolbar: d3.Selection<any>) {
-    const $sortButton = $toolbar.append('button')
-      .attr('class', 'fa sort fa-sort-amount-asc')
+    const $sortButton = $toolbar.append('a')
+      .attr('title', 'Sort descending')
+      .html(`<i class="fa fa-sort-amount-asc fa-fw" aria-hidden="true"></i><span class="sr-only">Sort descending</span>`)
       .on('click', () => {
-        if ($sortButton.classed('fa-sort-amount-asc')) {
-          // const sortMethod = SORT.desc;
+        if ($sortButton.select('i').classed('fa-sort-amount-asc')) {
           this.sortCriteria = SORT.desc;
           this.fire(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this);
-          $sortButton.attr('class', 'fa sort fa-sort-amount-desc');
+          $sortButton
+            .attr('title', 'Sort ascending')
+            .html(`<i class="fa fa-sort-amount-desc fa-fw" aria-hidden="true"></i><span class="sr-only">Sort ascending</span>`);
         } else {
           this.sortCriteria = SORT.asc;
           this.fire(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this);
-          $sortButton.attr('class', 'fa sort fa-sort-amount-asc');
+          $sortButton
+            .attr('title', 'Sort descending')
+            .html(`<i class="fa fa-sort-amount-asc fa-fw" aria-hidden="true"></i><span class="sr-only">Sort descending</span>`);
         }
       });
+
     super.buildToolbar($toolbar);
   }
 
-  updateSortIcon() {
+  private updateSortIcon() {
     if (this.sortCriteria === SORT.desc) {
-      const s = this.$node.select('.fa.sort.fa-sort-amount-asc');
-      s.attr('class', 'fa sort fa-sort-amount-desc');
-    }
-    if (this.sortCriteria === SORT.asc) {
-      const s = this.$node.select('.fa.sort.fa-sort-amount-desc');
-      s.attr('class', 'fa sort fa-sort-amount-asc');
+      this.$node.select('button.sort')
+        .attr('title', 'Sort ascending')
+        .html(`<i class="sort fa fa-sort-amount-desc fa-fw" aria-hidden="true"></i><span class="sr-only">Sort ascending</span>`);
+
+    } else if (this.sortCriteria === SORT.asc) {
+      this.$node.select('button.sort')
+        .attr('title', 'Sort descending')
+        .html(`<i class="sort fa fa-sort-amount-asc fa-fw" aria-hidden="true"></i><span class="sr-only">Sort descending</span>`);
     }
   }
 

--- a/src/column/CategoricalColumn.ts
+++ b/src/column/CategoricalColumn.ts
@@ -9,15 +9,15 @@ import {EOrientation} from './AColumn';
 import {mixin} from 'phovea_core/src/index';
 import VisManager from './VisManager';
 import {on, fire} from 'phovea_core/src/event';
-import CategoricalFilter from '../filter/CategoricalFilter';
 
 export default class CategoricalColumn extends AVectorColumn<string, ICategoricalVector> {
+
+  static readonly EVENT_STRATIFYME = 'stratifyByMe';
 
   minWidth: number = 2;
   maxWidth: number = 200; //80
   minHeight: number = 2;
   maxHeight: number = 10;
-  static readonly EVENT_STRATIFYME = 'stratifyByMe';
 
   constructor(data: ICategoricalVector, orientation: EOrientation, $parent: d3.Selection<any>) {
     super(data, orientation);
@@ -33,15 +33,17 @@ export default class CategoricalColumn extends AVectorColumn<string, ICategorica
 
 
   private attachListener() {
-    const that = this;
-    this.toolbar.insert('button', ':first-child')
-      .classed('fa fa-bars', true)
+    const $stratifyButton = this.toolbar.insert('a', ':first-child')
+      .attr('title', 'Stratify table by this column')
+      .html(`<i class="fa fa-bars fa-fw" aria-hidden="true"></i><span class="sr-only">Stratify table by this column</span>`)
       .on('click', () => {
         this.fire(CategoricalColumn.EVENT_STRATIFYME, this);
-        fire(CategoricalFilter.EVENT_STRATIFYME, this);
-
+        fire(CategoricalColumn.EVENT_STRATIFYME, this);
       });
 
+    on(CategoricalColumn.EVENT_STRATIFYME, (evt, ref) => {
+      $stratifyButton.classed('active', ref.data.desc.id === this.data.desc.id);
+    });
   }
 
 }

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -77,7 +77,7 @@ export default class ColumnManager extends EventHandler {
       .classed('columnList', true);
 
     $('.columnList', this.$parent.node()) // jquery
-      .sortable({handle: '.columnHeader', axis: 'x'});
+      .sortable({handle: '.labelName', axis: 'x'});
   }
 
   private attachListener() {

--- a/src/filter/AVectorFilter.ts
+++ b/src/filter/AVectorFilter.ts
@@ -20,29 +20,31 @@ export abstract class AVectorFilter<T, DATATYPE extends IVector<T, any>> extends
     const $li = $ol.append('li').classed('filter', true);
     const $header = $li.append('header');
     $li.append('main');
-    this.addSortIcon($header);
+    const $toolbar = $header.append('div').classed('toolbar', true);
+    this.addSortIcon($toolbar);
     return $li;
   }
 
 
-  private addSortIcon($node: d3.Selection<any>) {
-    // this.sortCriteria = SORT.asc;
-    const sortIconNode = $node.append('a').classed('fa sort fa-sort-amount-asc', true);
-    sortIconNode.on('click', () => {
-      const b = sortIconNode.attr('class');
-      if (b === 'fa sort fa-sort-amount-asc') {
-        const sortMethod = SORT.desc;
-        const sortData = {'sortMethod': sortMethod, col: this};
-        fire(AVectorFilter.EVENT_SORTBY_FILTER_ICON, sortData);
-        sortIconNode.attr('class', 'fa sort fa-sort-amount-desc');
-      } else {
-        const sortMethod = SORT.asc;
-        const sortData = {'sortMethod': sortMethod, col: this};
-        fire(AVectorFilter.EVENT_SORTBY_FILTER_ICON, sortData);
-        sortIconNode.attr('class', 'fa sort fa-sort-amount-asc');
-      }
-    });
-
+  protected addSortIcon($node: d3.Selection<any>) {
+    const $sortButton = $node.append('a')
+      .attr('title', 'Sort descending')
+      .html(`<i class="fa fa-sort-amount-asc fa-fw" aria-hidden="true"></i><span class="sr-only">Sort descending</span>`)
+      .on('click', () => {
+        if ($sortButton.select('i').classed('fa-sort-amount-asc')) {
+          $sortButton
+            .attr('title', 'Sort ascending')
+            .html(`<i class="fa fa-sort-amount-desc fa-fw" aria-hidden="true"></i><span class="sr-only">Sort ascending</span>`);
+          const sortData = {'sortMethod': SORT.desc, col: this};
+          fire(AVectorFilter.EVENT_SORTBY_FILTER_ICON, sortData);
+        } else {
+          $sortButton
+            .attr('title', 'Sort descending')
+            .html(`<i class="fa fa-sort-amount-asc fa-fw" aria-hidden="true"></i><span class="sr-only">Sort descending</span>`);
+          const sortData = {'sortMethod': SORT.asc, col: this};
+          fire(AVectorFilter.EVENT_SORTBY_FILTER_ICON, sortData);
+        }
+      });
   }
 
 

--- a/src/filter/CategoricalFilter.ts
+++ b/src/filter/CategoricalFilter.ts
@@ -15,15 +15,12 @@ export default class CategoricalFilter extends AVectorFilter<string, ICategorica
   private _filterDim: {width: number, height: number};
   private _activeCategories: string[];
   private _sortCriteria: string = SORT.asc;
-  static readonly EVENT_STRATIFYME = 'updateStratifyIcon';
 
 
   constructor(data: ICategoricalVector, $parent: d3.Selection<any>) {
     super(data);
     this.$node = this.build($parent);
     on(AVectorFilter.EVENT_SORTBY_FILTER_ICON, this.sortByFilterIcon.bind(this));
-    this.attachListener();
-
   }
 
   protected build($parent: d3.Selection<any>) {
@@ -34,19 +31,19 @@ export default class CategoricalFilter extends AVectorFilter<string, ICategorica
     return $node;
   }
 
-  private attachListener() {
-    const splitIcon = this.$node.select('header').insert('a', ':first-child')
-      .classed('fa fa-bars', true);
-    splitIcon.on('click', () => {
-      d3.selectAll('.fa.fa-bars').classed('active', false);
-      const b = splitIcon.attr('class');
-      if (b === 'fa fa-bars') {
+  protected addSortIcon($node: d3.Selection<any>) {
+    const $stratifyButton = $node.append('a')
+      .attr('title', 'Stratify table by this column')
+      .html(`<i class="fa fa-bars fa-fw" aria-hidden="true"></i><span class="sr-only">Stratify table by this column</span>`)
+      .on('click', () => {
         fire(CategoricalColumn.EVENT_STRATIFYME, this);
-        splitIcon.classed('active', true);
-      } else {
-        splitIcon.classed('active', false);
-      }
+      });
+
+    on(CategoricalColumn.EVENT_STRATIFYME, (evt, ref) => {
+      $stratifyButton.classed('active', ref.data.desc.id === this.data.desc.id);
     });
+
+    super.addSortIcon($node);
   }
 
 

--- a/src/filter/FilterManager.ts
+++ b/src/filter/FilterManager.ts
@@ -52,7 +52,6 @@ export default class FilterManager extends EventHandler {
   push(data: IFilterAbleType) {
     const filter = FilterManager.createFilter(data, this.$node);
     filter.on(AFilter.EVENT_FILTER_CHANGED, this.onFilterChanged);
-    on(CategoricalFilter.EVENT_STRATIFYME, this.stratifyMe.bind(this));
     this.filters.push(filter);
   }
 
@@ -66,14 +65,6 @@ export default class FilterManager extends EventHandler {
   contains(data: IFilterAbleType) {
     return this.filters.some((d) => d.data === data);
   }
-
-
-  private stratifyMe(evt, col) {
-    const colid = this.filters.filter((d) => d.data.desc.id === col.data.desc.id);
-    d3.selectAll('.fa.fa-bars').classed('active', false);
-    colid[0].$node.select('.fa.fa-bars').classed('active', true);
-  }
-
 
   /**
    * Removes the column from the filters by the given data parameter,

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Mother Table</title>
+    <title>Taggle</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <link href="//fonts.googleapis.com/css?family=Yantramanav:500,400,300" rel="stylesheet" type="text/css">

--- a/src/styles/_columnManager.scss
+++ b/src/styles/_columnManager.scss
@@ -41,7 +41,9 @@
       .toolbar {
         text-align: center;
 
+        div.visChooser,
         a {
+          display: inline-block;
           cursor: pointer;
           color: $toolbar-link-color;
 
@@ -55,9 +57,57 @@
             color: $toolbar-link-active-color;
           }
         }
-        a + a{
+
+        a + div.visChooser,
+        div.visChooser + a,
+        div.visChooser + div.visChooser,
+        a + a {
           margin-left: 5px;
         }
+
+        // correct y-position for rotated icon
+        i.fa-window-minimize {
+          transform: rotate(90deg) translateY(-5px);
+        }
+
+        div.visChooser {
+          position: relative;
+
+          div {
+            display: none;
+            flex-direction: column;
+            position: absolute;
+            z-index: 999;
+            background: #fff;
+            padding: 2px;
+            border: 1px solid $header-bg-color;
+
+            > i {
+              display: block;
+              cursor: pointer;
+              width: 1.2em;
+
+              /*&:after {
+                content: attr(title);
+              }*/
+
+              &:hover {
+                background: $header-bg-color;
+              }
+            }
+
+            > i + i {
+              margin-top: 3px;
+            }
+          }
+
+          &:hover {
+            div {
+              display: flex;
+            }
+          }
+        }
+
       }
     }
 

--- a/src/styles/_columnManager.scss
+++ b/src/styles/_columnManager.scss
@@ -6,24 +6,6 @@
   overflow: auto;
   margin-top: 2px;
 
-  .toolbar {
-    cursor: default;
-    display: none;
-    position: absolute;
-    right: 5px;
-    top: 0;
-    z-index: 1000;
-    padding: 5px;
-    background: $toolbar-bg-color;
-    border-radius: 3px;
-    border: 1px $header-border-color solid;
-
-    button,
-    .vislist i {
-      cursor: pointer;
-    }
-  }
-
   .columnList {
     display: flex;
     align-items: stretch;
@@ -38,21 +20,44 @@
 
     .columnHeader {
       display: flex;
-      align-items: center;
-      cursor: move;
-      height: 25px;
+      flex-direction: column;
       position: relative;
       background: $header-bg-color;
       margin-bottom: 2px;
       min-width: 10px;
+      padding: 3px;
 
-      span {
-        display: block;
-        width: 100%;
+      .labelName {
+        cursor: move;
+        align-items: center;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
         text-align: center;
+        font-weight: 500;
+        padding: 0 2px 3px;
+      }
+
+      .toolbar {
+        text-align: center;
+
+        a {
+          cursor: pointer;
+          color: $toolbar-link-color;
+
+          &:active,
+          &:focus,
+          &:hover {
+            color: $toolbar-link-hover-color;
+          }
+
+          &.active {
+            color: $toolbar-link-active-color;
+          }
+        }
+        a + a{
+          margin-left: 5px;
+        }
       }
     }
 

--- a/src/styles/_filterManager.scss
+++ b/src/styles/_filterManager.scss
@@ -68,12 +68,30 @@
       width: 200px;
     }
 
-    a {
+    .toolbar {
+      text-align: center;
       order: 2;
-      text-decoration: none;
-      cursor: pointer;
-      color: inherit;
       padding-right: 5px;
+      white-space: nowrap;
+
+      a {
+        text-decoration: none;
+        cursor: pointer;
+        color: $toolbar-link-color;
+
+        &:active,
+        &:focus,
+        &:hover {
+          color: $toolbar-link-hover-color;
+        }
+
+        &.active {
+          color: $toolbar-link-active-color;
+        }
+      }
+      a + a{
+        margin-left: 5px;
+      }
     }
   }
 

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -5,5 +5,8 @@ $hover-color: #ffc46b;
 
 $header-bg-color: #f0f0f0;
 $header-border-color: #ddd;
-$toolbar-bg-color: #fff;
 
+$toolbar-bg-color: #fff;
+$toolbar-link-color: #999;
+$toolbar-link-hover-color: #444;
+$toolbar-link-active-color: #d98000;


### PR DESCRIPTION
I added the vis chooser for aggregated/unaggregated visualizations and updated the icon style in the header according to the concept. 

![taggle_vis-chooser](https://cloud.githubusercontent.com/assets/5851088/24115844/f773dc90-0da4-11e7-8c54-52da352f31cc.gif)

**Note:** Please follow the steps to get all icons:
1. Pull `phovea_ui`
2. `yo povea:workspace`
3. `npm install`