### PR TITLE
Visualization switching

### DIFF
--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -146,7 +146,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
     defVis.innerText = "--";
     defVis.onclick  = () => {
       this.multiformList.forEach((mul) => {
-        if(aggregationType == VisManager.aggregationType.UNAGGREGATED){
+        if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
           delete VisManager.userSelectedUnaggregatedVisses[mul.id.toString()];
           this.selectedUnaggVis = null;
         }else{
@@ -162,7 +162,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
         const child = createNode(s, 'i');
         v.iconify(child);
         child.onclick = () => {
-          if(aggregationType == VisManager.aggregationType.UNAGGREGATED){
+          if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
             this.selectedUnaggVis = v;
           }else{
             this.selectedAggVis = v;

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -146,7 +146,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
     defVis.innerText = "--";
     defVis.onclick  = () => {
       this.multiformList.forEach((mul) => {
-        if(aggregationType == VisManager.aggregationType.UNAGGREGATED){
+        if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
           delete VisManager.userSelectedUnaggregatedVisses[mul.id.toString()];
           this.selectedUnaggVis = null;
         }else{
@@ -158,11 +158,11 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
     };
 
     visses.forEach((v) => {
-      if(visIds.indexOf(v.id) != -1){
+      if(visIds.indexOf(v.id) !== -1){
         const child = createNode(s, 'i');
         v.iconify(child);
         child.onclick = () => {
-          if(aggregationType == VisManager.aggregationType.UNAGGREGATED){
+          if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
             this.selectedUnaggVis = v;
           }else{
             this.selectedAggVis = v;

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -146,7 +146,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
     defVis.innerText = "--";
     defVis.onclick  = () => {
       this.multiformList.forEach((mul) => {
-        if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
+        if(aggregationType == VisManager.aggregationType.UNAGGREGATED){
           delete VisManager.userSelectedUnaggregatedVisses[mul.id.toString()];
           this.selectedUnaggVis = null;
         }else{
@@ -162,7 +162,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
         const child = createNode(s, 'i');
         v.iconify(child);
         child.onclick = () => {
-          if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
+          if(aggregationType == VisManager.aggregationType.UNAGGREGATED){
             this.selectedUnaggVis = v;
           }else{
             this.selectedAggVis = v;

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -8,6 +8,7 @@ import Range from 'phovea_core/src/range/Range';
 import {EventHandler} from 'phovea_core/src/event';
 import * as d3 from 'd3';
 import {SORT} from '../SortHandler/SortHandler';
+import {createNode} from 'phovea_core/src/multiform/internal';
 import AVectorFilter from '../filter/AVectorFilter';
 import {formatAttributeName} from './utils';
 import MultiForm from 'phovea_core/src/multiform/MultiForm';
@@ -131,20 +132,49 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
         return false;
       });
 
-    this.appendVisChooser(this.selectedAggVis, $toolbar, 'fa fa-ellipsis-v fa-fw', 'Select visualization for unaggregated areas');
-    this.appendVisChooser(this.selectedUnaggVis, $toolbar, 'fa fa-window-minimize fa-fw fa-rotate-90', 'Select visualization for aggregated areas');
+    this.appendVisChooser(this.selectedAggVis, $toolbar, 'fa fa-ellipsis-v fa-fw', 'Select visualization for unaggregated areas', VisManager.aggregationType.UNAGGREGATED);
+    this.appendVisChooser(this.selectedUnaggVis, $toolbar, 'fa fa-window-minimize fa-fw fa-rotate-90', 'Select visualization for aggregated areas', VisManager.aggregationType.AGGREGATED);
   }
 
-  private appendVisChooser(selectedVis:IVisPluginDesc, $toolbar:d3.Selection<any>, faIcon:string, title:string):IMultiForm {
+  private addIconVisChooser(toolbar: HTMLElement, multiform: MultiForm, aggregationType, selectedVis:IVisPluginDesc) {
+    const s = toolbar.ownerDocument.createElement('div');
+    toolbar.insertBefore(s, toolbar.firstChild);
+    const visses = multiform.visses;
+    const visIds = VisManager.getPossibleVisses(this.data.desc.type, this.data.desc.value.type, aggregationType);
+    const defVis = createNode(s, 'i');
+    defVis.innerText = "--";
+    defVis.onclick  = () => {
+      this.multiformList.forEach((mul) => {
+        if(aggregationType == VisManager.aggregationType.UNAGGREGATED){
+          delete VisManager.userSelectedUnaggregatedVisses[mul.id.toString()];
+        }else{
+          delete VisManager.userSelectedAggregatedVisses[mul.id.toString()];
+        }
+      });
+      //TODO force relayout
+    };
+
+    visses.forEach((v) => {
+      if(visIds.indexOf(v.id) != -1){
+        const child = createNode(s, 'i');
+        v.iconify(child);
+        child.onclick = () => {
+          selectedVis = v;
+          this.multiformList.forEach((mul) => {
+            VisManager.setUserVis(mul.id, v, aggregationType);
+           //TODO force relayout
+          });
+          console.log('selected', v);
+        }
+      }
+    });
+  }
+
+  private appendVisChooser(selectedVis:IVisPluginDesc, $toolbar:d3.Selection<any>, faIcon:string, title:string, aggregationType):IMultiForm {
     const $node = $toolbar.append('div').classed('visChooser', true);
 
     const m = new MultiForm(this.data, document.createElement('dummy-to-discard'), { initialVis: this.activeVis });
-    m.addIconVisChooser(<HTMLElement>$node.node());
-    m.on('change', (evt, vis) => {
-      selectedVis = vis;
-      console.log('selected', vis);
-    });
-
+    this.addIconVisChooser(<HTMLElement>$node.node(), m, aggregationType, selectedVis);
     $node.insert('i', ':first-child')
       .attr('title', title)
       .attr('class', faIcon)

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -42,69 +42,99 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   rangeView: Range;
   multiformList = [];
 
-  selectedAggVis:IVisPluginDesc;
-  selectedUnaggVis:IVisPluginDesc;
+  selectedAggVis: IVisPluginDesc;
+  selectedUnaggVis: IVisPluginDesc;
 
-  constructor(public readonly data: DATATYPE, public readonly orientation: EOrientation) {
-    super();
-  }
+  constructor(public readonly
 
-  get idtype() {
-    return this.data.idtypes[0];
-  }
+  data: DATATYPE
+,
+  public readonly orientation: EOrientation
+) {
+  super();
+}
 
-  get body() {
-    return this.$node.select(':scope > main'); // :scope = enforce direct children
-  }
+get
+idtype()
+{
+  return this.data.idtypes[0];
+}
 
-  get header() {
-    return this.$node.select('header.columnHeader');
-  }
+get
+body()
+{
+  return this.$node.select(':scope > main'); // :scope = enforce direct children
+}
 
-  get toolbar() {
-    return this.$node.select('header > .toolbar');
-  }
+get
+header()
+{
+  return this.$node.select('header.columnHeader');
+}
 
-  protected build($parent: d3.Selection<any>): d3.Selection<any> {
-    if (this.orientation === EOrientation.Horizontal) {
-      return this.buildHorizontal($parent);
-    }
-    return this.buildVertical($parent);
-  }
+get
+toolbar()
+{
+  return this.$node.select('header > .toolbar');
+}
 
-  /**
-   * Add template for stratifications columns (in the header )
-   * @param $parent
-   * @returns {Selection<any>}
-   */
-  protected buildVertical($parent: d3.Selection<any>): d3.Selection<any> {
-    const $node = $parent.insert('li', 'li')
-      .datum(this)
-      .classed('column-strat', true)
-      .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
-      .html(`
+protected
+build($parent
+:
+d3.Selection < any >
+):
+d3.Selection < any > {
+  if (this.orientation === EOrientation.Horizontal
+)
+{
+  return this.buildHorizontal($parent);
+}
+return this.buildVertical($parent);
+}
+
+/**
+ * Add template for stratifications columns (in the header )
+ * @param $parent
+ * @returns {Selection<any>}
+ */
+protected
+buildVertical($parent
+:
+d3.Selection < any >
+):
+d3.Selection < any > {
+  const $node = $parent.insert('li', 'li')
+    .datum(this)
+    .classed('column-strat', true)
+    .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
+    .html(`
         <header>
           <div class="labelName">${formatAttributeName(this.data.desc.name)}</div>
         </header> 
         <main></main>
       `);
-    return $node;
-  }
+return $node;
+}
 
-  /**
-   * Add template for regular columns (in the main view)
-   * @param $parent
-   * @returns {Selection<any>}
-   */
-  protected buildHorizontal($parent: d3.Selection<any>): d3.Selection<any> {
-    const $node = $parent
-      .append('li')
-      .datum(this)
-      .classed('column', true)
-      .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
-      .style('min-width', this.minWidth + 'px')
-      .style('width', this.maxWidth + 'px')
-      .html(`
+/**
+ * Add template for regular columns (in the main view)
+ * @param $parent
+ * @returns {Selection<any>}
+ */
+protected
+buildHorizontal($parent
+:
+d3.Selection < any >
+):
+d3.Selection < any > {
+  const $node = $parent
+    .append('li')
+    .datum(this)
+    .classed('column', true)
+    .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
+    .style('min-width', this.minWidth + 'px')
+    .style('width', this.maxWidth + 'px')
+    .html(`
         <aside></aside>
         <header class="columnHeader">
           <div class="labelName">${formatAttributeName(this.data.desc.name)}</div>
@@ -112,114 +142,143 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
         </header>
         <main></main>`);
 
-    this.buildToolbar($node.select('div.toolbar'));
+this.buildToolbar($node.select('div.toolbar'));
 
-    return $node;
-  }
+return $node;
+}
 
-  protected buildToolbar($toolbar: d3.Selection<any>) {
-    const $lockButton = $toolbar.append('a')
-      .attr('title', 'Lock column')
-      .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`)
-      .on('click', () => {
-        this.lockColumnWidth($lockButton);
-      });
+protected
+buildToolbar($toolbar
+:
+d3.Selection < any >
+)
+{
+  const $lockButton = $toolbar.append('a')
+    .attr('title', 'Lock column')
+    .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`)
+    .on('click', () => {
+      this.lockColumnWidth($lockButton);
+    });
 
-    $toolbar.append('a')
-      .attr('title', 'Remove column')
-      .html(`<i class="fa fa-trash fa-fw" aria-hidden="true"></i><span class="sr-only">Remove column</span>`)
-      .on('click', () => {
-        this.fire(AColumn.EVENT_REMOVE_ME);
-        return false;
-      });
+  $toolbar.append('a')
+    .attr('title', 'Remove column')
+    .html(`<i class="fa fa-trash fa-fw" aria-hidden="true"></i><span class="sr-only">Remove column</span>`)
+    .on('click', () => {
+      this.fire(AColumn.EVENT_REMOVE_ME);
+      return false;
+    });
 
-    this.appendVisChooser($toolbar, 'fa fa-ellipsis-v fa-fw', 'Select visualization for unaggregated areas', VisManager.aggregationType.UNAGGREGATED);
-    this.appendVisChooser($toolbar, 'fa fa-window-minimize fa-fw fa-rotate-90', 'Select visualization for aggregated areas', VisManager.aggregationType.AGGREGATED);
-  }
+  this.appendVisChooser($toolbar, 'fa fa-ellipsis-v fa-fw', 'Select visualization for unaggregated areas', VisManager.aggregationType.UNAGGREGATED);
+  this.appendVisChooser($toolbar, 'fa fa-window-minimize fa-fw fa-rotate-90', 'Select visualization for aggregated areas', VisManager.aggregationType.AGGREGATED);
+}
 
-  private addIconVisChooser(toolbar: HTMLElement, multiform: MultiForm, aggregationType) {
-    const s = toolbar.ownerDocument.createElement('div');
-    toolbar.insertBefore(s, toolbar.firstChild);
-    const visses = multiform.visses;
-    const visIds = VisManager.getPossibleVisses(this.data.desc.type, this.data.desc.value.type, aggregationType);
-    const defVis = createNode(s, 'i');
-    defVis.innerText = "--";
-    defVis.onclick  = () => {
-      this.multiformList.forEach((mul) => {
-        if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
-          delete VisManager.userSelectedUnaggregatedVisses[mul.id.toString()];
-          this.selectedUnaggVis = null;
-        }else{
-          delete VisManager.userSelectedAggregatedVisses[mul.id.toString()];
-          this.selectedAggVis = null;
-        }
-      });
-      this.fire(AColumn.VISUALIZATION_SWITCHED);
-    };
-
-    visses.forEach((v) => {
-      if(visIds.indexOf(v.id) !== -1){
-        const child = createNode(s, 'i');
-        v.iconify(child);
-        child.onclick = () => {
-          if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
-            this.selectedUnaggVis = v;
-          }else{
-            this.selectedAggVis = v;
-           }
-          this.multiformList.forEach((mul) => {
-            VisManager.setUserVis(mul.id, v, aggregationType);
-          });
-          this.fire(AColumn.VISUALIZATION_SWITCHED);
-          console.log('selected', v);
-        }
+private
+addIconVisChooser(toolbar
+:
+HTMLElement, multiform
+:
+MultiForm, aggregationType
+)
+{
+  const s = toolbar.ownerDocument.createElement('div');
+  toolbar.insertBefore(s, toolbar.firstChild);
+  const visses = multiform.visses;
+  const visIds = VisManager.getPossibleVisses(this.data.desc.type, this.data.desc.value.type, aggregationType);
+  const defVis = createNode(s, 'i');
+  defVis.innerText = "--";
+  defVis.onclick = () => {
+    this.multiformList.forEach((mul) => {
+      if (aggregationType === VisManager.aggregationType.UNAGGREGATED) {
+        delete VisManager.userSelectedUnaggregatedVisses[mul.id.toString()];
+        this.selectedUnaggVis = null;
+      } else {
+        delete VisManager.userSelectedAggregatedVisses[mul.id.toString()];
+        this.selectedAggVis = null;
       }
     });
-  }
+    this.fire(AColumn.VISUALIZATION_SWITCHED);
+  };
 
-  private appendVisChooser($toolbar:d3.Selection<any>, faIcon:string, title:string, aggregationType):IMultiForm {
-    const $node = $toolbar.append('div').classed('visChooser', true);
-
-    const m = new MultiForm(this.data, document.createElement('dummy-to-discard'), { initialVis: this.activeVis });
-    this.addIconVisChooser(<HTMLElement>$node.node(), m, aggregationType);
-    $node.insert('i', ':first-child')
-      .attr('title', title)
-      .attr('class', faIcon)
-      .attr('aria-hidden', 'true');
-
-    $node
-      .append('span')
-      .attr('class', 'sr-only')
-      .text(title);
-
-    return m;
-  }
-
-
-  async updateMultiForms(rowRanges: Range[]) {
-    // hook
-  }
-
-  protected lockColumnWidth($lockButton) {
-    if ($lockButton.select('i').classed('fa-lock')) {
-      // UNLOCKING
-      $lockButton
-        .classed('active', false)
-        .attr('title', 'Lock column')
-        .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`);
-      this.lockedWidth = -1;
-      this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'unlocked');
-
-    } else {
-      // LOCKING
-      $lockButton
-        .classed('active', true)
-        .attr('title', 'Unlock column')
-        .html(`<i class="fa fa-lock fa-fw" aria-hidden="true"></i><span class="sr-only">Unlock column</span>`);
-      this.lockedWidth = this.$node.property('clientWidth');
-      this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'locked');
+  visses.forEach((v) => {
+    if (visIds.indexOf(v.id) !== -1) {
+      const child = createNode(s, 'i');
+      v.iconify(child);
+      child.onclick = () => {
+        if (aggregationType === VisManager.aggregationType.UNAGGREGATED) {
+          this.selectedUnaggVis = v;
+        } else {
+          this.selectedAggVis = v;
+        }
+        this.multiformList.forEach((mul) => {
+          VisManager.setUserVis(mul.id, v, aggregationType);
+        });
+        this.fire(AColumn.VISUALIZATION_SWITCHED);
+        console.log('selected', v);
+      }
     }
+  });
+}
+
+private
+appendVisChooser($toolbar
+:
+d3.Selection < any >, faIcon
+:
+string, title
+:
+string, aggregationType
+):
+IMultiForm
+{
+  const $node = $toolbar.append('div').classed('visChooser', true);
+
+  const m = new MultiForm(this.data, document.createElement('dummy-to-discard'), {initialVis: this.activeVis});
+  this.addIconVisChooser(<HTMLElement>$node.node(), m, aggregationType);
+  $node.insert('i', ':first-child')
+    .attr('title', title)
+    .attr('class', faIcon)
+    .attr('aria-hidden', 'true');
+
+  $node
+    .append('span')
+    .attr('class', 'sr-only')
+    .text(title);
+
+  return m;
+}
+
+
+async
+updateMultiForms(rowRanges
+:
+Range[]
+)
+{
+  // hook
+}
+
+protected
+lockColumnWidth($lockButton)
+{
+  if ($lockButton.select('i').classed('fa-lock')) {
+    // UNLOCKING
+    $lockButton
+      .classed('active', false)
+      .attr('title', 'Lock column')
+      .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`);
+    this.lockedWidth = -1;
+    this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'unlocked');
+
+  } else {
+    // LOCKING
+    $lockButton
+      .classed('active', true)
+      .attr('title', 'Unlock column')
+      .html(`<i class="fa fa-lock fa-fw" aria-hidden="true"></i><span class="sr-only">Unlock column</span>`);
+    this.lockedWidth = this.$node.property('clientWidth');
+    this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'locked');
   }
+}
 
 
 }

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -9,7 +9,6 @@ import {EventHandler} from 'phovea_core/src/event';
 import * as d3 from 'd3';
 import {SORT} from '../SortHandler/SortHandler';
 import {createNode} from 'phovea_core/src/multiform/internal';
-import AVectorFilter from '../filter/AVectorFilter';
 import {formatAttributeName} from './utils';
 import MultiForm from 'phovea_core/src/multiform/MultiForm';
 import {IMultiForm} from 'phovea_core/src/multiform/IMultiForm';

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -42,99 +42,69 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   rangeView: Range;
   multiformList = [];
 
-  selectedAggVis: IVisPluginDesc;
-  selectedUnaggVis: IVisPluginDesc;
+  selectedAggVis:IVisPluginDesc;
+  selectedUnaggVis:IVisPluginDesc;
 
-  constructor(public readonly
+  constructor(public readonly data: DATATYPE, public readonly orientation: EOrientation) {
+    super();
+  }
 
-  data: DATATYPE
-,
-  public readonly orientation: EOrientation
-) {
-  super();
-}
+  get idtype() {
+    return this.data.idtypes[0];
+  }
 
-get
-idtype()
-{
-  return this.data.idtypes[0];
-}
+  get body() {
+    return this.$node.select(':scope > main'); // :scope = enforce direct children
+  }
 
-get
-body()
-{
-  return this.$node.select(':scope > main'); // :scope = enforce direct children
-}
+  get header() {
+    return this.$node.select('header.columnHeader');
+  }
 
-get
-header()
-{
-  return this.$node.select('header.columnHeader');
-}
+  get toolbar() {
+    return this.$node.select('header > .toolbar');
+  }
 
-get
-toolbar()
-{
-  return this.$node.select('header > .toolbar');
-}
+  protected build($parent: d3.Selection<any>): d3.Selection<any> {
+    if (this.orientation === EOrientation.Horizontal) {
+      return this.buildHorizontal($parent);
+    }
+    return this.buildVertical($parent);
+  }
 
-protected
-build($parent
-:
-d3.Selection < any >
-):
-d3.Selection < any > {
-  if (this.orientation === EOrientation.Horizontal
-)
-{
-  return this.buildHorizontal($parent);
-}
-return this.buildVertical($parent);
-}
-
-/**
- * Add template for stratifications columns (in the header )
- * @param $parent
- * @returns {Selection<any>}
- */
-protected
-buildVertical($parent
-:
-d3.Selection < any >
-):
-d3.Selection < any > {
-  const $node = $parent.insert('li', 'li')
-    .datum(this)
-    .classed('column-strat', true)
-    .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
-    .html(`
+  /**
+   * Add template for stratifications columns (in the header )
+   * @param $parent
+   * @returns {Selection<any>}
+   */
+  protected buildVertical($parent: d3.Selection<any>): d3.Selection<any> {
+    const $node = $parent.insert('li', 'li')
+      .datum(this)
+      .classed('column-strat', true)
+      .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
+      .html(`
         <header>
           <div class="labelName">${formatAttributeName(this.data.desc.name)}</div>
         </header> 
         <main></main>
       `);
-return $node;
-}
+    return $node;
+  }
 
-/**
- * Add template for regular columns (in the main view)
- * @param $parent
- * @returns {Selection<any>}
- */
-protected
-buildHorizontal($parent
-:
-d3.Selection < any >
-):
-d3.Selection < any > {
-  const $node = $parent
-    .append('li')
-    .datum(this)
-    .classed('column', true)
-    .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
-    .style('min-width', this.minWidth + 'px')
-    .style('width', this.maxWidth + 'px')
-    .html(`
+  /**
+   * Add template for regular columns (in the main view)
+   * @param $parent
+   * @returns {Selection<any>}
+   */
+  protected buildHorizontal($parent: d3.Selection<any>): d3.Selection<any> {
+    const $node = $parent
+      .append('li')
+      .datum(this)
+      .classed('column', true)
+      .classed('column-' + (this.orientation === EOrientation.Horizontal ? 'hor' : 'ver'), true)
+      .style('min-width', this.minWidth + 'px')
+      .style('width', this.maxWidth + 'px')
+      .html(`
         <aside></aside>
         <header class="columnHeader">
           <div class="labelName">${formatAttributeName(this.data.desc.name)}</div>
@@ -142,143 +112,114 @@ d3.Selection < any > {
         </header>
         <main></main>`);
 
-this.buildToolbar($node.select('div.toolbar'));
+    this.buildToolbar($node.select('div.toolbar'));
 
-return $node;
-}
-
-protected
-buildToolbar($toolbar
-:
-d3.Selection < any >
-)
-{
-  const $lockButton = $toolbar.append('a')
-    .attr('title', 'Lock column')
-    .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`)
-    .on('click', () => {
-      this.lockColumnWidth($lockButton);
-    });
-
-  $toolbar.append('a')
-    .attr('title', 'Remove column')
-    .html(`<i class="fa fa-trash fa-fw" aria-hidden="true"></i><span class="sr-only">Remove column</span>`)
-    .on('click', () => {
-      this.fire(AColumn.EVENT_REMOVE_ME);
-      return false;
-    });
-
-  this.appendVisChooser($toolbar, 'fa fa-ellipsis-v fa-fw', 'Select visualization for unaggregated areas', VisManager.aggregationType.UNAGGREGATED);
-  this.appendVisChooser($toolbar, 'fa fa-window-minimize fa-fw fa-rotate-90', 'Select visualization for aggregated areas', VisManager.aggregationType.AGGREGATED);
-}
-
-private
-addIconVisChooser(toolbar
-:
-HTMLElement, multiform
-:
-MultiForm, aggregationType
-)
-{
-  const s = toolbar.ownerDocument.createElement('div');
-  toolbar.insertBefore(s, toolbar.firstChild);
-  const visses = multiform.visses;
-  const visIds = VisManager.getPossibleVisses(this.data.desc.type, this.data.desc.value.type, aggregationType);
-  const defVis = createNode(s, 'i');
-  defVis.innerText = "--";
-  defVis.onclick = () => {
-    this.multiformList.forEach((mul) => {
-      if (aggregationType === VisManager.aggregationType.UNAGGREGATED) {
-        delete VisManager.userSelectedUnaggregatedVisses[mul.id.toString()];
-        this.selectedUnaggVis = null;
-      } else {
-        delete VisManager.userSelectedAggregatedVisses[mul.id.toString()];
-        this.selectedAggVis = null;
-      }
-    });
-    this.fire(AColumn.VISUALIZATION_SWITCHED);
-  };
-
-  visses.forEach((v) => {
-    if (visIds.indexOf(v.id) !== -1) {
-      const child = createNode(s, 'i');
-      v.iconify(child);
-      child.onclick = () => {
-        if (aggregationType === VisManager.aggregationType.UNAGGREGATED) {
-          this.selectedUnaggVis = v;
-        } else {
-          this.selectedAggVis = v;
-        }
-        this.multiformList.forEach((mul) => {
-          VisManager.setUserVis(mul.id, v, aggregationType);
-        });
-        this.fire(AColumn.VISUALIZATION_SWITCHED);
-        console.log('selected', v);
-      }
-    }
-  });
-}
-
-private
-appendVisChooser($toolbar
-:
-d3.Selection < any >, faIcon
-:
-string, title
-:
-string, aggregationType
-):
-IMultiForm
-{
-  const $node = $toolbar.append('div').classed('visChooser', true);
-
-  const m = new MultiForm(this.data, document.createElement('dummy-to-discard'), {initialVis: this.activeVis});
-  this.addIconVisChooser(<HTMLElement>$node.node(), m, aggregationType);
-  $node.insert('i', ':first-child')
-    .attr('title', title)
-    .attr('class', faIcon)
-    .attr('aria-hidden', 'true');
-
-  $node
-    .append('span')
-    .attr('class', 'sr-only')
-    .text(title);
-
-  return m;
-}
-
-
-async
-updateMultiForms(rowRanges
-:
-Range[]
-)
-{
-  // hook
-}
-
-protected
-lockColumnWidth($lockButton)
-{
-  if ($lockButton.select('i').classed('fa-lock')) {
-    // UNLOCKING
-    $lockButton
-      .classed('active', false)
-      .attr('title', 'Lock column')
-      .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`);
-    this.lockedWidth = -1;
-    this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'unlocked');
-
-  } else {
-    // LOCKING
-    $lockButton
-      .classed('active', true)
-      .attr('title', 'Unlock column')
-      .html(`<i class="fa fa-lock fa-fw" aria-hidden="true"></i><span class="sr-only">Unlock column</span>`);
-    this.lockedWidth = this.$node.property('clientWidth');
-    this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'locked');
+    return $node;
   }
-}
+
+  protected buildToolbar($toolbar: d3.Selection<any>) {
+    const $lockButton = $toolbar.append('a')
+      .attr('title', 'Lock column')
+      .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`)
+      .on('click', () => {
+        this.lockColumnWidth($lockButton);
+      });
+
+    $toolbar.append('a')
+      .attr('title', 'Remove column')
+      .html(`<i class="fa fa-trash fa-fw" aria-hidden="true"></i><span class="sr-only">Remove column</span>`)
+      .on('click', () => {
+        this.fire(AColumn.EVENT_REMOVE_ME);
+        return false;
+      });
+
+    this.appendVisChooser($toolbar, 'fa fa-ellipsis-v fa-fw', 'Select visualization for unaggregated areas', VisManager.aggregationType.UNAGGREGATED);
+    this.appendVisChooser($toolbar, 'fa fa-window-minimize fa-fw fa-rotate-90', 'Select visualization for aggregated areas', VisManager.aggregationType.AGGREGATED);
+  }
+
+  private addIconVisChooser(toolbar: HTMLElement, multiform: MultiForm, aggregationType) {
+    const s = toolbar.ownerDocument.createElement('div');
+    toolbar.insertBefore(s, toolbar.firstChild);
+    const visses = multiform.visses;
+    const visIds = VisManager.getPossibleVisses(this.data.desc.type, this.data.desc.value.type, aggregationType);
+    const defVis = createNode(s, 'i');
+    defVis.innerText = "--";
+    defVis.onclick  = () => {
+      this.multiformList.forEach((mul) => {
+        if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
+          delete VisManager.userSelectedUnaggregatedVisses[mul.id.toString()];
+          this.selectedUnaggVis = null;
+        }else{
+          delete VisManager.userSelectedAggregatedVisses[mul.id.toString()];
+          this.selectedAggVis = null;
+        }
+      });
+      this.fire(AColumn.VISUALIZATION_SWITCHED);
+    };
+
+    visses.forEach((v) => {
+      if(visIds.indexOf(v.id) !== -1){
+        const child = createNode(s, 'i');
+        v.iconify(child);
+        child.onclick = () => {
+          if(aggregationType === VisManager.aggregationType.UNAGGREGATED){
+            this.selectedUnaggVis = v;
+          }else{
+            this.selectedAggVis = v;
+           }
+          this.multiformList.forEach((mul) => {
+            VisManager.setUserVis(mul.id, v, aggregationType);
+          });
+          this.fire(AColumn.VISUALIZATION_SWITCHED);
+          console.log('selected', v);
+        }
+      }
+    });
+  }
+
+  private appendVisChooser($toolbar:d3.Selection<any>, faIcon:string, title:string, aggregationType):IMultiForm {
+    const $node = $toolbar.append('div').classed('visChooser', true);
+
+    const m = new MultiForm(this.data, document.createElement('dummy-to-discard'), { initialVis: this.activeVis });
+    this.addIconVisChooser(<HTMLElement>$node.node(), m, aggregationType);
+    $node.insert('i', ':first-child')
+      .attr('title', title)
+      .attr('class', faIcon)
+      .attr('aria-hidden', 'true');
+
+    $node
+      .append('span')
+      .attr('class', 'sr-only')
+      .text(title);
+
+    return m;
+  }
+
+
+  async updateMultiForms(rowRanges: Range[]) {
+    // hook
+  }
+
+  protected lockColumnWidth($lockButton) {
+    if ($lockButton.select('i').classed('fa-lock')) {
+      // UNLOCKING
+      $lockButton
+        .classed('active', false)
+        .attr('title', 'Lock column')
+        .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`);
+      this.lockedWidth = -1;
+      this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'unlocked');
+
+    } else {
+      // LOCKING
+      $lockButton
+        .classed('active', true)
+        .attr('title', 'Unlock column')
+        .html(`<i class="fa fa-lock fa-fw" aria-hidden="true"></i><span class="sr-only">Unlock column</span>`);
+      this.lockedWidth = this.$node.property('clientWidth');
+      this.fire(AColumn.EVENT_COLUMN_LOCK_CHANGED, 'locked');
+    }
+  }
 
 
 }

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -101,29 +101,27 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
           });
         const m = new MultiForm(view, <HTMLElement>$multiformdivs.node(), this.multiFormParams($multiformdivs, domain));
         //assign visses
-        if(this.selectedAggVis){
-            VisManager.userSelectedAggregatedVisses[m.id.toString()] = this.selectedAggVis;
-         }
-        if(this.selectedUnaggVis){
-            VisManager.userSelectedUnaggregatedVisses[m.id.toString()] = this.selectedUnaggVis;
+        if (this.selectedAggVis) {
+          VisManager.userSelectedAggregatedVisses[m.id.toString()] = this.selectedAggVis;
+        }
+        if (this.selectedUnaggVis) {
+          VisManager.userSelectedUnaggregatedVisses[m.id.toString()] = this.selectedUnaggVis;
         }
         VisManager.setMultiformAggregationType(m.id.toString(), VisManager.aggregationType.UNAGGREGATED);
         this.multiformList.push(m);
         const r = (<any>m).data.range;
-        let isSuccesor = Object.keys(idList).some((l, index) => {
-          let newRange = r.dims[0].asList().toString();
-          let originalRange = idList[l].dims[0].toString();
-          if (newRange === originalRange) {
+        Object.keys(idList).some((l) => {
+          let newRange = r.dims[0].asList();
+          let originalRange = idList[l].dims[0].asList();
+          if (newRange.toString() === originalRange.toString()) {
             VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
             return true;
           } else {
-            let newRangeList = r.dims[0].asList().sort((a, b) => (a - b));
-            let oldRangeList = idList[l].dims[0].asList().sort((a, b) => (a - b));
-            if (this.superbag(oldRangeList, newRangeList)) {
+            if (this.superbag(originalRange, newRange)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
               return true;
             }
-            if (this.superbag(newRangeList, oldRangeList)) {
+            if (this.superbag(newRange, originalRange)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
               return true;
             }
@@ -138,17 +136,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
   }
 
   private superbag(sup, sub) {
-    let i, j;
-    for (i=0,j=0; i<sup.length && j<sub.length;) {
-        if (sup[i] < sub[j]) {
-            ++i;
-        } else if (sup[i] === sub[j]) {
-            ++i; ++j;
-        } else {
-            return false;
-        }
-    }
-    return j === sub.length;
+    return sub.every(elem => sup.indexOf(elem) > -1);
   }
 
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -103,11 +103,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
             d3.select(this).select('.vislist').style('display', 'none');
           });
         const m = new MultiForm(view, <HTMLElement>$multiformdivs.node(), this.multiFormParams($multiformdivs, domain));
-        if( Object.keys(idList).length == 0){
-          isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[id] || false;
-        }
         //assign visses
-        let vissagg = this.selectedAggVis;
         if(this.selectedAggVis){
             VisManager.userSelectedAggregatedVisses[m.id.toString()] = this.selectedAggVis;
          }
@@ -117,7 +113,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
         VisManager.setMultiformAggregationType(m.id.toString(), VisManager.aggregationType.UNAGGREGATED);
         this.multiformList.push(m);
         const r = (<any>m).data.range;
-        Object.keys(idList).some((l, index) => {
+        let isSuccesor = Object.keys(idList).some((l, index) => {
           let newRange = r.dims[0].asList().toString();
           let originalRange = idList[l].dims[0].toString();
           if (newRange == originalRange) {
@@ -139,6 +135,9 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
             }
           }
         });
+        if(!isSuccesor || Object.keys(idList).length == 0){
+          isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[id] || false;
+        }
       });
       VisManager.isUserSelectedUnaggregatedRow = isUserUnagregated;
       Object.keys(idList).forEach((l) => {

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -8,10 +8,8 @@ import {IStringValueTypeDesc, IDataType} from 'phovea_core/src/datatype';
 import Range from 'phovea_core/src/range/Range';
 import {IMultiFormOptions} from 'phovea_core/src/multiform';
 import {SORT} from '../SortHandler/SortHandler';
-import {scaleTo} from './utils';
 import * as d3 from 'd3';
 import MultiForm from 'phovea_core/src/multiform/MultiForm';
-import {IMultiForm} from '../../../phovea_core/src/multiform/IMultiForm';
 import VisManager from './VisManager';
 export declare type IStringVector = IVector<string, IStringValueTypeDesc>;
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -116,7 +116,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
         let isSuccesor = Object.keys(idList).some((l, index) => {
           let newRange = r.dims[0].asList().toString();
           let originalRange = idList[l].dims[0].toString();
-          if (newRange == originalRange) {
+          if (newRange === originalRange) {
             VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
             isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
             return true;
@@ -135,7 +135,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
             }
           }
         });
-        if(!isSuccesor || Object.keys(idList).length == 0){
+        if(!isSuccesor || Object.keys(idList).length === 0){
           isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[id] || false;
         }
       });
@@ -152,13 +152,13 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     for (i=0,j=0; i<sup.length && j<sub.length;) {
         if (sup[i] < sub[j]) {
             ++i;
-        } else if (sup[i] == sub[j]) {
+        } else if (sup[i] === sub[j]) {
             ++i; ++j;
         } else {
             return false;
         }
     }
-    return j == sub.length;
+    return j === sub.length;
   }
 
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -87,6 +87,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
       this.multiformList.forEach((m) => {
         idList[m.id] = m.data.range;
       });
+
       this.body.selectAll('.multiformList').remove();
       this.multiformList = [];
       let isUserUnagregated  = [];
@@ -102,6 +103,17 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
             d3.select(this).select('.vislist').style('display', 'none');
           });
         const m = new MultiForm(view, <HTMLElement>$multiformdivs.node(), this.multiFormParams($multiformdivs, domain));
+        if( Object.keys(idList).length == 0){
+          isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[id] || false;
+        }
+        //assign visses
+        let vissagg = this.selectedAggVis;
+        if(this.selectedAggVis){
+            VisManager.userSelectedAggregatedVisses[m.id.toString()] = this.selectedAggVis;
+         }
+        if(this.selectedUnaggVis){
+            VisManager.userSelectedUnaggregatedVisses[m.id.toString()] = this.selectedUnaggVis;
+        }
         VisManager.setMultiformAggregationType(m.id.toString(), VisManager.aggregationType.UNAGGREGATED);
         this.multiformList.push(m);
         const r = (<any>m).data.range;
@@ -110,7 +122,6 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
           let originalRange = idList[l].dims[0].toString();
           if (newRange == originalRange) {
             VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
-            VisManager.updateUserVis(l, m.id.toString());
             isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
             return true;
           } else {
@@ -118,29 +129,22 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
             let oldRangeList = idList[l].dims[0].asList().sort((a, b) => (a - b));
             if (this.superbag(oldRangeList, newRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
-              VisManager.updateUserVis(l, m.id.toString());
               isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
             if (this.superbag(newRangeList, oldRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
-              VisManager.updateUserVis(l, m.id.toString());
               isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
           }
         });
-        if( Object.keys(idList).length == 0){
-          isUserUnagregated = VisManager.isUserSelectedUnaggregatedRow;
-        }
       });
       VisManager.isUserSelectedUnaggregatedRow = isUserUnagregated;
       Object.keys(idList).forEach((l) => {
         delete VisManager.multiformAggregationType[l];
         VisManager.removeUserVisses(l);
       });
-
-
     });
   }
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -90,7 +90,6 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
 
       this.body.selectAll('.multiformList').remove();
       this.multiformList = [];
-      let isUserUnagregated  = [];
 
       views.forEach((view, id) => {
         const $multiformdivs = this.body.append('div').classed('multiformList', true);
@@ -118,28 +117,21 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
           let originalRange = idList[l].dims[0].toString();
           if (newRange === originalRange) {
             VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
-            isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
             return true;
           } else {
             let newRangeList = r.dims[0].asList().sort((a, b) => (a - b));
             let oldRangeList = idList[l].dims[0].asList().sort((a, b) => (a - b));
             if (this.superbag(oldRangeList, newRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
-              isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
             if (this.superbag(newRangeList, oldRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
-              isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
           }
         });
-        if(!isSuccesor || Object.keys(idList).length === 0){
-          isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[id] || false;
-        }
       });
-      VisManager.isUserSelectedUnaggregatedRow = isUserUnagregated;
       Object.keys(idList).forEach((l) => {
         delete VisManager.multiformAggregationType[l];
         VisManager.removeUserVisses(l);

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -135,6 +135,11 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     });
   }
 
+  /*
+   *Checks if one array contains all elements of another array
+   *@sup the larger array
+   *@sub the smaller array
+   */
   private superbag(sup, sub) {
     return sub.every(elem => sup.indexOf(elem) > -1);
   }

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -116,23 +116,30 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
         let isSuccesor = Object.keys(idList).some((l, index) => {
           let newRange = r.dims[0].asList().toString();
           let originalRange = idList[l].dims[0].toString();
-          if (newRange === originalRange) {
+          if (newRange == originalRange) {
             VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
+            isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
             return true;
           } else {
             let newRangeList = r.dims[0].asList().sort((a, b) => (a - b));
             let oldRangeList = idList[l].dims[0].asList().sort((a, b) => (a - b));
             if (this.superbag(oldRangeList, newRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
+              isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
             if (this.superbag(newRangeList, oldRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
+              isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
           }
         });
+        if(!isSuccesor || Object.keys(idList).length == 0){
+          isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[id] || false;
+        }
       });
+      VisManager.isUserSelectedUnaggregatedRow = isUserUnagregated;
       Object.keys(idList).forEach((l) => {
         delete VisManager.multiformAggregationType[l];
         VisManager.removeUserVisses(l);
@@ -145,13 +152,13 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     for (i=0,j=0; i<sup.length && j<sub.length;) {
         if (sup[i] < sub[j]) {
             ++i;
-        } else if (sup[i] === sub[j]) {
+        } else if (sup[i] == sub[j]) {
             ++i; ++j;
         } else {
             return false;
         }
     }
-    return j === sub.length;
+    return j == sub.length;
   }
 
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -101,29 +101,27 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
           });
         const m = new MultiForm(view, <HTMLElement>$multiformdivs.node(), this.multiFormParams($multiformdivs, domain));
         //assign visses
-        if(this.selectedAggVis){
-            VisManager.userSelectedAggregatedVisses[m.id.toString()] = this.selectedAggVis;
-         }
-        if(this.selectedUnaggVis){
-            VisManager.userSelectedUnaggregatedVisses[m.id.toString()] = this.selectedUnaggVis;
+        if (this.selectedAggVis) {
+          VisManager.userSelectedAggregatedVisses[m.id.toString()] = this.selectedAggVis;
+        }
+        if (this.selectedUnaggVis) {
+          VisManager.userSelectedUnaggregatedVisses[m.id.toString()] = this.selectedUnaggVis;
         }
         VisManager.setMultiformAggregationType(m.id.toString(), VisManager.aggregationType.UNAGGREGATED);
         this.multiformList.push(m);
         const r = (<any>m).data.range;
-        let isSuccesor = Object.keys(idList).some((l, index) => {
-          let newRange = r.dims[0].asList().toString();
-          let originalRange = idList[l].dims[0].toString();
-          if (newRange === originalRange) {
+        Object.keys(idList).some((l) => {
+          let newRange = r.dims[0].asList();
+          let originalRange = idList[l].dims[0].asList();
+          if (newRange.toString() === originalRange.toString()) {
             VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
             return true;
           } else {
-            let newRangeList = r.dims[0].asList().sort((a, b) => (a - b));
-            let oldRangeList = idList[l].dims[0].asList().sort((a, b) => (a - b));
-            if (this.superbag(oldRangeList, newRangeList)) {
+            if (this.superbag(originalRange, newRange)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
               return true;
             }
-            if (this.superbag(newRangeList, oldRangeList)) {
+            if (this.superbag(newRange, originalRange)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
               return true;
             }
@@ -137,18 +135,13 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     });
   }
 
+  /*
+   *Checks if one array contains all elements of another array
+   *@sup rhe larger array
+   *@sub the smaller array
+   */
   private superbag(sup, sub) {
-    let i, j;
-    for (i=0,j=0; i<sup.length && j<sub.length;) {
-        if (sup[i] < sub[j]) {
-            ++i;
-        } else if (sup[i] === sub[j]) {
-            ++i; ++j;
-        } else {
-            return false;
-        }
-    }
-    return j === sub.length;
+    return sub.every(elem => sup.indexOf(elem) > -1);
   }
 
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -137,10 +137,11 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
 
   /**
    * Checks if one array contains all elements of another array
-   * @sup the larger array
-   * @sub the smaller array
+   * @param sup the larger array
+   * @param sub the smaller array
+   * @returns {boolean}
    */
-  private superbag(sup, sub) {
+  private superbag(sup:any[], sub:any[]):boolean {
     return sub.every(elem => sup.indexOf(elem) > -1);
   }
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -91,16 +91,27 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
         });
       const view = await this.data.idView(r);
       const m = new MultiForm(view, <HTMLElement>multiformdivs.node(), this.multiFormParams(multiformdivs, domain));
-      Object.keys(idList).forEach((l) => {
+
+      Object.keys(idList).some((l) => {
         let newRange = r.dims[0].asList().toString();
         let originalRange = idList[l].dims[0].toString();
+        //set the vis for the same multiform
+        //TODO performance: move this test higher, so the multiform with unchanged range is not redrawn
         if(newRange == originalRange){
-            VisManager.updateUserVis(l, m.id.toString());
+          VisManager.updateUserVis(l, m.id.toString());
+          return true;
         }else{
           let newRangeList = r.dims[0].asList().sort((a, b) => (a - b));
           let oldRangeList = idList[l].dims[0].asList().sort((a, b) => (a - b));
+          //set the vis for split multiform
           if(this.superbag(oldRangeList, newRangeList)){
             VisManager.updateUserVis(l, m.id.toString());
+            return true;
+          }
+          //set the vis for merged multiform
+          if(this.superbag(newRangeList, oldRangeList)){
+            VisManager.updateUserVis(l, m.id.toString());
+            return true;
           }
         }
       });
@@ -137,6 +148,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
       child.onclick = () => {
         multiform.switchTo(v);
         VisManager.setUserVis(multiform.id, v);
+
       };
     });
   }

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -135,10 +135,10 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     });
   }
 
-  /*
-   *Checks if one array contains all elements of another array
-   *@sup the larger array
-   *@sub the smaller array
+  /**
+   * Checks if one array contains all elements of another array
+   * @sup the larger array
+   * @sub the smaller array
    */
   private superbag(sup, sub) {
     return sub.every(elem => sup.indexOf(elem) > -1);

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -92,13 +92,13 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
       const view = await this.data.idView(r);
       const m = new MultiForm(view, <HTMLElement>multiformdivs.node(), this.multiFormParams(multiformdivs, domain));
 
-      Object.keys(idList).some((l) => {
+    /*  Object.keys(idList).some((l) => {
         let newRange = r.dims[0].asList().toString();
         let originalRange = idList[l].dims[0].toString();
         //set the vis for the same multiform
         //TODO performance: move this test higher, so the multiform with unchanged range is not redrawn
         if(newRange == originalRange){
-          VisManager.updateUserVis(l, m.id.toString());
+          VisManager.updateUserVis(l, m.id.toString(),);
           return true;
         }else{
           let newRangeList = r.dims[0].asList().sort((a, b) => (a - b));
@@ -114,12 +114,12 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
             return true;
           }
         }
-      });
+      });*/
       this.addIconVisChooser(<HTMLElement>$header.node(), m);
       this.multiformList.push(m);
     }
     Object.keys(idList).forEach((l) => {
-      VisManager.removeUserVis(l);
+      VisManager.removeUserVisses(l);
     });
   }
 
@@ -142,7 +142,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     toolbar.insertBefore(s, toolbar.firstChild);
     const visses = multiform.visses;
 
-    visses.forEach((v) => {
+ /*   visses.forEach((v) => {
       const child = createNode(s, 'i');
       v.iconify(child);
       child.onclick = () => {
@@ -150,7 +150,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
         VisManager.setUserVis(multiform.id, v);
 
       };
-    });
+    });*/
   }
 
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -116,30 +116,23 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
         let isSuccesor = Object.keys(idList).some((l, index) => {
           let newRange = r.dims[0].asList().toString();
           let originalRange = idList[l].dims[0].toString();
-          if (newRange == originalRange) {
+          if (newRange === originalRange) {
             VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
-            isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
             return true;
           } else {
             let newRangeList = r.dims[0].asList().sort((a, b) => (a - b));
             let oldRangeList = idList[l].dims[0].asList().sort((a, b) => (a - b));
             if (this.superbag(oldRangeList, newRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
-              isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
             if (this.superbag(newRangeList, oldRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
-              isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
           }
         });
-        if(!isSuccesor || Object.keys(idList).length == 0){
-          isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[id] || false;
-        }
       });
-      VisManager.isUserSelectedUnaggregatedRow = isUserUnagregated;
       Object.keys(idList).forEach((l) => {
         delete VisManager.multiformAggregationType[l];
         VisManager.removeUserVisses(l);
@@ -152,13 +145,13 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     for (i=0,j=0; i<sup.length && j<sub.length;) {
         if (sup[i] < sub[j]) {
             ++i;
-        } else if (sup[i] == sub[j]) {
+        } else if (sup[i] === sub[j]) {
             ++i; ++j;
         } else {
             return false;
         }
     }
-    return j == sub.length;
+    return j === sub.length;
   }
 
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -9,7 +9,6 @@ import Range from 'phovea_core/src/range/Range';
 import {IMultiFormOptions} from 'phovea_core/src/multiform';
 import {SORT} from '../SortHandler/SortHandler';
 import {scaleTo} from './utils';
-import {createNode} from 'phovea_core/src/multiform/internal';
 import * as d3 from 'd3';
 import MultiForm from 'phovea_core/src/multiform/MultiForm';
 import {IMultiForm} from '../../../phovea_core/src/multiform/IMultiForm';
@@ -111,6 +110,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
           let originalRange = idList[l].dims[0].toString();
           if (newRange == originalRange) {
             VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
+            VisManager.updateUserVis(l, m.id.toString());
             isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
             return true;
           } else {
@@ -118,11 +118,13 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
             let oldRangeList = idList[l].dims[0].asList().sort((a, b) => (a - b));
             if (this.superbag(oldRangeList, newRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
+              VisManager.updateUserVis(l, m.id.toString());
               isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
             if (this.superbag(newRangeList, oldRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
+              VisManager.updateUserVis(l, m.id.toString());
               isUserUnagregated[id] = VisManager.isUserSelectedUnaggregatedRow[index];
               return true;
             }
@@ -135,7 +137,10 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
       VisManager.isUserSelectedUnaggregatedRow = isUserUnagregated;
       Object.keys(idList).forEach((l) => {
         delete VisManager.multiformAggregationType[l];
+        VisManager.removeUserVisses(l);
       });
+
+
     });
   }
 
@@ -153,21 +158,6 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     return j == sub.length;
   }
 
-  private addIconVisChooser(toolbar: HTMLElement, multiform: MultiForm) {
-    const s = toolbar.ownerDocument.createElement('div');
-    toolbar.insertBefore(s, toolbar.firstChild);
-    const visses = multiform.visses;
-
- /*   visses.forEach((v) => {
-      const child = createNode(s, 'i');
-      v.iconify(child);
-      child.onclick = () => {
-        multiform.switchTo(v);
-        VisManager.setUserVis(multiform.id, v);
-
-      };
-    });*/
-  }
 
 }
 

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -101,27 +101,29 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
           });
         const m = new MultiForm(view, <HTMLElement>$multiformdivs.node(), this.multiFormParams($multiformdivs, domain));
         //assign visses
-        if (this.selectedAggVis) {
-          VisManager.userSelectedAggregatedVisses[m.id.toString()] = this.selectedAggVis;
-        }
-        if (this.selectedUnaggVis) {
-          VisManager.userSelectedUnaggregatedVisses[m.id.toString()] = this.selectedUnaggVis;
+        if(this.selectedAggVis){
+            VisManager.userSelectedAggregatedVisses[m.id.toString()] = this.selectedAggVis;
+         }
+        if(this.selectedUnaggVis){
+            VisManager.userSelectedUnaggregatedVisses[m.id.toString()] = this.selectedUnaggVis;
         }
         VisManager.setMultiformAggregationType(m.id.toString(), VisManager.aggregationType.UNAGGREGATED);
         this.multiformList.push(m);
         const r = (<any>m).data.range;
-        Object.keys(idList).some((l) => {
-          let newRange = r.dims[0].asList();
-          let originalRange = idList[l].dims[0].asList();
-          if (newRange.toString() === originalRange.toString()) {
+        let isSuccesor = Object.keys(idList).some((l, index) => {
+          let newRange = r.dims[0].asList().toString();
+          let originalRange = idList[l].dims[0].toString();
+          if (newRange === originalRange) {
             VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
             return true;
           } else {
-            if (this.superbag(originalRange, newRange)) {
+            let newRangeList = r.dims[0].asList().sort((a, b) => (a - b));
+            let oldRangeList = idList[l].dims[0].asList().sort((a, b) => (a - b));
+            if (this.superbag(oldRangeList, newRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
               return true;
             }
-            if (this.superbag(newRange, originalRange)) {
+            if (this.superbag(newRangeList, oldRangeList)) {
               VisManager.setMultiformAggregationType(m.id.toString(), VisManager.multiformAggregationType[l]);
               return true;
             }
@@ -135,13 +137,18 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     });
   }
 
-  /*
-   *Checks if one array contains all elements of another array
-   *@sup rhe larger array
-   *@sub the smaller array
-   */
   private superbag(sup, sub) {
-    return sub.every(elem => sup.indexOf(elem) > -1);
+    let i, j;
+    for (i=0,j=0; i<sup.length && j<sub.length;) {
+        if (sup[i] < sub[j]) {
+            ++i;
+        } else if (sup[i] === sub[j]) {
+            ++i; ++j;
+        } else {
+            return false;
+        }
+    }
+    return j === sub.length;
   }
 
 

--- a/src/column/CategoricalColumn.ts
+++ b/src/column/CategoricalColumn.ts
@@ -14,7 +14,7 @@ export default class CategoricalColumn extends AVectorColumn<string, ICategorica
   minWidth: number = 2;
   maxWidth: number = 200; //80
   minHeight: number = 2;
-  maxHeight: number = 10;
+  maxHeight: number = 25;
 
   constructor(data: ICategoricalVector, orientation: EOrientation, $parent: d3.Selection<any>) {
     super(data, orientation);

--- a/src/column/CategoricalColumn.ts
+++ b/src/column/CategoricalColumn.ts
@@ -23,7 +23,7 @@ export default class CategoricalColumn extends AVectorColumn<string, ICategorica
 
   protected multiFormParams($body: d3.Selection<any>): IMultiFormOptions {
     return mixin(super.multiFormParams($body), {
-      initialVis: VisManager.getDefaultVis(this.data.desc.type, this.data.desc.value.type),
+      initialVis: VisManager.getDefaultVis(this.data.desc.type, this.data.desc.value.type, VisManager.aggregationType.UNAGGREGATED),
     });
   }
 

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -295,6 +295,19 @@ export default class ColumnManager extends EventHandler {
     });
   }
 
+  private buildRows(){
+
+  }
+
+  public updateAggregationType (multiformID : string){
+    this.columns.forEach((col) => {
+    //  col.multiformList.forEach(())
+
+    });
+
+  }
+
+
   /**
    * Calculate the maximum height of all column stratification areas and set it for every column
    */
@@ -439,6 +452,7 @@ export default class ColumnManager extends EventHandler {
         VisManager.setMultiformAggregationType(col.multiformList[rowIndex].id, aggregationType);
     }
   }
+
 }
 
 

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -69,359 +69,348 @@ export default class ColumnManager extends EventHandler {
   };
 
 
-  constructor(public readonly
+  constructor(public readonly idType: IDType, public readonly orientation: EOrientation, public readonly $parent: d3.Selection<any>) {
+    super();
+    this.build();
+    this.attachListener();
+  }
 
-  idType: IDType
-,
-  public readonly orientation: EOrientation
-,
-  public readonly $parent: d3.Selection<any>
-) {
-  super();
+  private build() {
+    this.visManager = new VisManager();
 
-  this
-.
-  build();
+    this.$node = this.$parent
+      .classed('column-manager', true)
+      .append('ol')
+      .classed('columnList', true);
 
-  this
-.
-  attachListener();
-}
+    $('.columnList', this.$parent.node()) // jquery
+      .sortable({
+        handle: '.labelName',
+        axis: 'x',
+        items: '> :not(.nodrag)'
+      });
 
-private
-build()
-{
-  this.visManager = new VisManager();
+    this.aggSwitcherCol = new AggSwitcherColumn(null, EOrientation.Horizontal, this.$node);
+  }
 
-  this.$node = this.$parent
-    .classed('column-manager', true)
-    .append('ol')
-    .classed('columnList', true);
-
-  $('.columnList', this.$parent.node()) // jquery
-    .sortable({
-      handle: '.labelName',
-      axis: 'x',
-      items: '> :not(.nodrag)'
+  private attachListener() {
+    on(AVectorFilter.EVENT_SORTBY_FILTER_ICON, (evt: any, sortData: {sortMethod: string, col: AFilter<string,IMotherTableType>}) => {
+      const col = this.filtersHierarchy.filter((d) => d.data.desc.id === sortData.col.data.desc.id);
+      col[0].sortCriteria = sortData.sortMethod;
+      this.updateColumns();
     });
 
-  this.aggSwitcherCol = new AggSwitcherColumn(null, EOrientation.Horizontal, this.$node);
-}
+    on(CategoricalColumn.EVENT_STRATIFYME, (evt: any, colid) => {
 
-private
-attachListener()
-{
-  on(AVectorFilter.EVENT_SORTBY_FILTER_ICON, (evt: any, sortData: {sortMethod: string, col: AFilter<string,IMotherTableType>}) => {
-    const col = this.filtersHierarchy.filter((d) => d.data.desc.id === sortData.col.data.desc.id);
-    col[0].sortCriteria = sortData.sortMethod;
-    this.updateColumns();
-  });
-
-  on(CategoricalColumn.EVENT_STRATIFYME, (evt: any, colid) => {
-
-    const col = this.filtersHierarchy.filter((d) => d.data.desc.id === colid.data.desc.id);
-    this.stratifyColid = col[0].data.desc.id;
-    this.stratifyAndRelayout();
-  });
-
-  this.aggSwitcherCol.on(AggSwitcherColumn.EVENT_GROUP_AGG_CHANGED, (evt: any, index: number, value: AggMode, allGroups: AggMode[]) => {
-    console.log(index, value, allGroups);
-  });
-}
-
-get
-length()
-{
-  return this.columns.length;
-}
-
-destroy()
-{
-  // delete all columns, can't remove myself, since I'm using the parent
-  this.$parent.selectAll('.column').remove();
-}
-
-/**
- * Adding a new column from given data
- * Called when adding a new filter from dropdown or from hash
- *
- * @param data
- * @returns {Promise<AnyColumn>}
- */
-async
-push(data
-:
-IMotherTableType
-)
-{
-  // if (data.idtypes[0] !== this.idType) {
-  //   throw new Error('invalid idtype');
-  // }
-  const col = createColumn(data, this.orientation, this.$node);
-
-  if (this.firstColumnRange === undefined) {
-    this.firstColumnRange = await
-    data.ids();
-  }
-
-  col.on(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
-  col.on(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this.onSortByColumnHeader);
-  col.on(AColumn.EVENT_COLUMN_LOCK_CHANGED, this.onLockChange);
-  col.on(CategoricalColumn.EVENT_STRATIFYME, this.stratifyMe);
-  col.on(AColumn.VISUALIZATION_SWITCHED, this.onVisChange);
-
-  this.columns.push(col);
-
-  // add column to hierarchy if it isn't a matrix and already added
-  const id = this.filtersHierarchy.filter((c) => c.data.desc.id === col.data.desc.id);
-  if (col.data.desc.type !== AColumn.DATATYPE.matrix && id.length === 0) {
-    this.filtersHierarchy.push(col);
-  }
-
-  return col;
-}
-
-remove(col
-:
-AnyColumn
-)
-{
-  this.columns.splice(this.columns.indexOf(col), 1);
-  col.$node.remove();
-  col.off(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
-  col.off(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this.onSortByColumnHeader);
-  col.off(AColumn.EVENT_COLUMN_LOCK_CHANGED, this.onLockChange);
-  col.off(AColumn.VISUALIZATION_SWITCHED, this.onVisChange);
-  this.fire(ColumnManager.EVENT_COLUMN_REMOVED, col);
-  this.fire(ColumnManager.EVENT_DATA_REMOVED, col.data);
-  this.updateColumns();
-}
-
-/**
- * move a column at the given index
- * @param col
- * @param index
- */
-move(col
-:
-AnyColumn, index
-:
-number
-)
-{
-  const old = this.columns.indexOf(col);
-  if (old === index) {
-    return;
-  }
-  //move the dom element, too
-  this.$parent.node().insertBefore(col.$node.node(), this.$parent.node().childNodes[index]);
-
-  this.columns.splice(old, 1);
-  if (old < index) {
-    index -= 1; //shifted because of deletion
-  }
-  this.columns.splice(index, 0, col);
-  this.relayout();
-}
-
-/**
- * Apply a filtered range to all columns
- * @param idRange
- * @returns {Promise<void>}
- */
-async
-filterData(idRange
-:
-Range
-)
-{
-  if (isNumber(idRange.ndim) !== true || idRange.size()[0] === 0) {
-    this.columns.forEach((col) => col.updateMultiForms([idRange]));
-    return;
-  }
-
-  for (const col of this.columns) {
-    col.rangeView = idRange;
-    col.dataView = await
-    col.data.idView(idRange);
-  }
-
-  this.updateColumns();
-}
-
-/**
- * Find corresponding columns for given list of filters and update the sorted  hierarchy
- * @param filterList
- */
-mapFiltersAndSort(filterList
-:
-AnyFilter[]
-)
-{
-  this.filtersHierarchy = filterList.map((d) => this.columns.filter((c) => c.data === d.data)[0]);
-  this.updateColumns();
-}
-
-/**
- * Sort, stratify and render all columns
- */
-async
-updateColumns()
-{
-  await
-  this.sortColumns();
-  await
-  this.stratifyAndRelayout();
-}
-
-async
-stratifyAndRelayout()
-{
-  this.updateStratifyID(this.stratifyColid);
-  await
-  this.stratifyColumns();
-  this.relayout();
-}
-
-/**
- * Sorting the ranges based on the filter hierarchy
- */
-private async
-sortColumns()
-{
-  const cols = this.filtersHierarchy;
-
-  //special handling if matrix is added as first column
-  if (cols.length === 0) {
-    this.nonStratifiedRange = this.firstColumnRange;
-    this.stratifiedRanges = [this.firstColumnRange];
-    return;
-  }
-
-  // The sort object is created on the fly and destroyed after it exits this method
-  const s = new SortHandler();
-  const r = await
-  s.sortColumns(cols);
-  this.nonStratifiedRange = r.combined;
-  this.stratifiedRanges = [r.combined];
-  this.dataPerStratificaiton = r.stratified;
-  cols.forEach((col) => {
-    this.colsWithRange.set(col.data.desc.id, [this.nonStratifiedRange]);
-  });
-
-  const categoricalCol = cols.filter((c) => c.data.desc.value.type === VALUE_TYPE_CATEGORICAL);
-  if (categoricalCol.length > 0 && this.stratifyColid === undefined) {
-    this.stratifyColid = categoricalCol[0].data.desc.id;
-  }
-}
-
-private async
-updateStratifyID(colid)
-{
-  if (colid === undefined) {
-    return;
-  }
-
-  this.stratifyColid = colid;
-  const cols = this.filtersHierarchy;
-  const datas = this.dataPerStratificaiton.get(colid);
-  const prepareRange = prepareRangeFromList(makeListFromRange(this.nonStratifiedRange), [datas]);
-  this.stratifiedRanges = prepareRange[0].map((d) => makeRangeFromList(d));
-  cols.forEach((col) => {
-    this.colsWithRange.set(col.data.desc.id, this.stratifiedRanges);
-  });
-}
-
-/**
- *
- * @param idRange
- * @returns {Promise<void>}
- */
-private async
-stratifyColumns()
-{
-  const vectorCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.vector);
-  vectorCols.forEach((col) => {
-    const r = this.colsWithRange.get(col.data.desc.id);
-    col.updateMultiForms(r);
-  });
-
-  // update matrix column with last sorted range
-  const matrixCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.matrix);
-  matrixCols.map((col) => col.updateMultiForms(this.stratifiedRanges));
-
-  // update aggregation switcher column
-  this.aggSwitcherCol.updateMultiForms(this.stratifiedRanges);
-}
-
-async
-relayout()
-{
-  await
-  resolveIn(10);
-  this.relayoutColStrats();
-  const header = 47;//TODO solve programatically
-  const height = Math.min(...this.columns.map((c) => c.$node.property('clientHeight') - header));
-  const rowHeight = await
-  this.calColHeight(height);
-  const colWidths = distributeColWidths(this.columns, this.$parent.property('clientWidth'));
-
-  if (this.columns.length > 0) {
-    this.aggSwitcherCol.updateSwitcherBlocks(this.columns[0].multiformList.map((d, i) => rowHeight[0][i]));
-  }
-
-  this.columns.forEach((col, i) => {
-    col.$node.style('width', colWidths[i] + 'px');
-
-    col.multiformList.forEach((multiform, index) => {
-      this.visManager.assignVis(multiform, colWidths[i], rowHeight[i][index]);
-      scaleTo(multiform, colWidths[i], rowHeight[i][index], col.orientation);
+      const col = this.filtersHierarchy.filter((d) => d.data.desc.id === colid.data.desc.id);
+      this.stratifyColid = col[0].data.desc.id;
+      this.stratifyAndRelayout();
     });
-  });
-}
 
-/**
- * Calculate the maximum height of all column stratification areas and set it for every column
- */
-private
-relayoutColStrats()
-{
-  const $strats = this.$node.selectAll('aside')
-    .style('height', null); // remove height first, to calculate a new one
-  const maxHeight = Math.max(...$strats[0].map((d: HTMLElement) => d.clientHeight));
-  $strats.style('height', maxHeight + 'px');
-}
-
-private async
-calColHeight(height)
-{
-  let ranges = [];
-  let minHeights = [];
-  let maxHeights = [];
-  let index = 0;
-  let totalMin = 0;
-  let totalMax = 0;
-
-
-  //switch all visses that can be switched to unaggregated and test if they can be shown as unaggregated
-  /****************************************************************************************/
-  for (let i = 0; i < this.columns[0].multiformList.length; i++) {
-    this.updateAggregationLevelForRow(i, VisManager.aggregationType.UNAGGREGATED);
+    this.aggSwitcherCol.on(AggSwitcherColumn.EVENT_GROUP_AGG_CHANGED, (evt:any, index:number, value:AggMode, allGroups:AggMode[]) => {
+      console.log(index, value, allGroups);
+    });
   }
 
-  //first run - check if the unagregatted columns fit and if not, switch all non-user-unaggregated rows to aggregated
-  let aggregationNeeded = false;
-  for (const col of this.columns) {
-    const minSizes = this.visManager.computeMinHeight(col);
-    if (d3.sum(minSizes) > height) {
-      aggregationNeeded = true;
+  get length() {
+    return this.columns.length;
+  }
+
+  destroy() {
+    // delete all columns, can't remove myself, since I'm using the parent
+    this.$parent.selectAll('.column').remove();
+  }
+
+  /**
+   * Adding a new column from given data
+   * Called when adding a new filter from dropdown or from hash
+   *
+   * @param data
+   * @returns {Promise<AnyColumn>}
+   */
+  async push(data: IMotherTableType) {
+    // if (data.idtypes[0] !== this.idType) {
+    //   throw new Error('invalid idtype');
+    // }
+    const col = createColumn(data, this.orientation, this.$node);
+
+    if (this.firstColumnRange === undefined) {
+      this.firstColumnRange = await data.ids();
     }
-    minHeights.push(minSizes);
+
+    col.on(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
+    col.on(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this.onSortByColumnHeader);
+    col.on(AColumn.EVENT_COLUMN_LOCK_CHANGED, this.onLockChange);
+    col.on(CategoricalColumn.EVENT_STRATIFYME, this.stratifyMe);
+    col.on(AColumn.VISUALIZATION_SWITCHED, this.onVisChange);
+
+    this.columns.push(col);
+
+    // add column to hierarchy if it isn't a matrix and already added
+    const id = this.filtersHierarchy.filter((c) => c.data.desc.id === col.data.desc.id);
+    if (col.data.desc.type !== AColumn.DATATYPE.matrix && id.length === 0) {
+      this.filtersHierarchy.push(col);
+    }
+
+    return col;
   }
 
-  if (!aggregationNeeded) {
+  remove(col: AnyColumn) {
+    this.columns.splice(this.columns.indexOf(col), 1);
+    col.$node.remove();
+    col.off(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
+    col.off(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this.onSortByColumnHeader);
+    col.off(AColumn.EVENT_COLUMN_LOCK_CHANGED, this.onLockChange);
+    col.off(AColumn.VISUALIZATION_SWITCHED, this.onVisChange);
+    this.fire(ColumnManager.EVENT_COLUMN_REMOVED, col);
+    this.fire(ColumnManager.EVENT_DATA_REMOVED, col.data);
+    this.updateColumns();
+  }
+
+  /**
+   * move a column at the given index
+   * @param col
+   * @param index
+   */
+  move(col: AnyColumn, index: number) {
+    const old = this.columns.indexOf(col);
+    if (old === index) {
+      return;
+    }
+    //move the dom element, too
+    this.$parent.node().insertBefore(col.$node.node(), this.$parent.node().childNodes[index]);
+
+    this.columns.splice(old, 1);
+    if (old < index) {
+      index -= 1; //shifted because of deletion
+    }
+    this.columns.splice(index, 0, col);
+    this.relayout();
+  }
+
+  /**
+   * Apply a filtered range to all columns
+   * @param idRange
+   * @returns {Promise<void>}
+   */
+  async filterData(idRange: Range) {
+    if (isNumber(idRange.ndim) !== true || idRange.size()[0] === 0) {
+      this.columns.forEach((col) => col.updateMultiForms([idRange]));
+      return;
+    }
+
+    for (const col of this.columns) {
+      col.rangeView = idRange;
+      col.dataView = await col.data.idView(idRange);
+    }
+
+    this.updateColumns();
+  }
+
+  /**
+   * Find corresponding columns for given list of filters and update the sorted  hierarchy
+   * @param filterList
+   */
+  mapFiltersAndSort(filterList: AnyFilter[]) {
+    this.filtersHierarchy = filterList.map((d) => this.columns.filter((c) => c.data === d.data)[0]);
+    this.updateColumns();
+  }
+
+  /**
+   * Sort, stratify and render all columns
+   */
+  async updateColumns() {
+    await this.sortColumns();
+    await this.stratifyAndRelayout();
+  }
+
+  async stratifyAndRelayout() {
+    this.updateStratifyID(this.stratifyColid);
+    await this.stratifyColumns();
+    this.relayout();
+  }
+
+  /**
+   * Sorting the ranges based on the filter hierarchy
+   */
+  private async sortColumns() {
+    const cols = this.filtersHierarchy;
+
+    //special handling if matrix is added as first column
+    if (cols.length === 0) {
+      this.nonStratifiedRange = this.firstColumnRange;
+      this.stratifiedRanges = [this.firstColumnRange];
+      return;
+    }
+
+    // The sort object is created on the fly and destroyed after it exits this method
+    const s = new SortHandler();
+    const r = await s.sortColumns(cols);
+    this.nonStratifiedRange = r.combined;
+    this.stratifiedRanges = [r.combined];
+    this.dataPerStratificaiton = r.stratified;
+    cols.forEach((col) => {
+      this.colsWithRange.set(col.data.desc.id, [this.nonStratifiedRange]);
+    });
+
+    const categoricalCol = cols.filter((c) => c.data.desc.value.type === VALUE_TYPE_CATEGORICAL);
+    if (categoricalCol.length > 0 && this.stratifyColid === undefined) {
+      this.stratifyColid = categoricalCol[0].data.desc.id;
+    }
+  }
+
+  private async updateStratifyID(colid) {
+    if (colid === undefined) {
+      return;
+    }
+
+    this.stratifyColid = colid;
+    const cols = this.filtersHierarchy;
+    const datas = this.dataPerStratificaiton.get(colid);
+    const prepareRange = prepareRangeFromList(makeListFromRange(this.nonStratifiedRange), [datas]);
+    this.stratifiedRanges = prepareRange[0].map((d) => makeRangeFromList(d));
+    cols.forEach((col) => {
+      this.colsWithRange.set(col.data.desc.id, this.stratifiedRanges);
+    });
+  }
+
+  /**
+   *
+   * @param idRange
+   * @returns {Promise<void>}
+   */
+  private async stratifyColumns() {
+    const vectorCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.vector);
+    vectorCols.forEach((col) => {
+      const r = this.colsWithRange.get(col.data.desc.id);
+      col.updateMultiForms(r);
+    });
+
+    // update matrix column with last sorted range
+    const matrixCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.matrix);
+    matrixCols.map((col) => col.updateMultiForms(this.stratifiedRanges));
+
+    // update aggregation switcher column
+    this.aggSwitcherCol.updateMultiForms(this.stratifiedRanges);
+  }
+
+  async relayout() {
+    await resolveIn(10);
+    this.relayoutColStrats();
+    const header = 47;//TODO solve programatically
+    const height = Math.min(...this.columns.map((c) => c.$node.property('clientHeight') - header));
+    const rowHeight = await this.calColHeight(height);
+    const colWidths = distributeColWidths(this.columns, this.$parent.property('clientWidth'));
+
+    if(this.columns.length > 0) {
+      this.aggSwitcherCol.updateSwitcherBlocks(this.columns[0].multiformList.map((d, i) => rowHeight[0][i]));
+    }
+
+    this.columns.forEach((col, i) => {
+      col.$node.style('width', colWidths[i] + 'px');
+
+      col.multiformList.forEach((multiform, index) => {
+        this.visManager.assignVis(multiform, colWidths[i], rowHeight[i][index]);
+        scaleTo(multiform, colWidths[i], rowHeight[i][index], col.orientation);
+      });
+    });
+  }
+
+  /**
+   * Calculate the maximum height of all column stratification areas and set it for every column
+   */
+  private relayoutColStrats() {
+    const $strats = this.$node.selectAll('aside')
+      .style('height', null); // remove height first, to calculate a new one
+    const maxHeight = Math.max(...$strats[0].map((d: HTMLElement) => d.clientHeight));
+    $strats.style('height', maxHeight + 'px');
+  }
+
+  private async calColHeight(height) {
+    let ranges = [];
+    let minHeights = [];
+    let maxHeights = [];
+    let index = 0;
+    let totalMin = 0;
+    let totalMax = 0;
+
+
+    //switch all visses that can be switched to unaggregated and test if they can be shown as unaggregated
+    /****************************************************************************************/
+    for(let i =0; i< this.columns[0].multiformList.length; i++){
+        this.updateAggregationLevelForRow(i, VisManager.aggregationType.UNAGGREGATED);
+    }
+
+    //first run - check if the unagregatted columns fit and if not, switch all non-user-unaggregated rows to aggregated
+    let aggregationNeeded = false;
+    for (const col of this.columns) {
+      const minSizes = this.visManager.computeMinHeight(col);
+      if (d3.sum(minSizes) > height) {
+        aggregationNeeded = true;
+      }
+      minHeights.push(minSizes);
+    }
+
+    if(!aggregationNeeded) {
+      //choose minimal block height for each row of multiforms/stratification group
+      for (let i = 0; i < this.columns[0].multiformList.length; i++) {
+        let minSize = [];
+        minHeights.forEach((m) => {
+          minSize.push(m[i]);
+        });
+        let min = Math.max(...minSize);
+        minHeights.forEach((m) => {
+          m[i] = min;
+        });
+        totalMin = totalMin + min;
+      }
+      if(totalMin > height){
+        aggregationNeeded = true;
+      }
+    }
+
+    /*************************************************************************/
+
+    totalMin = 0;
+    minHeights = [];
+
+
+    for(let i =0; i< this.columns[0].multiformList.length; i++){
+      let aggMode = aggregationNeeded ? VisManager.aggregationType.AGGREGATED : VisManager.aggregationType.UNAGGREGATED;
+      this.updateAggregationLevelForRow(i, aggMode);
+    }
+
+
+    //copute height requiremmts per column
+    for (const col of this.columns) {
+      const type = col.data.desc.type;
+      let range = this.colsWithRange.get(col.data.desc.id);
+      const temp = [];
+
+      if (range === undefined) {
+        range = this.stratifiedRanges;
+      }
+      const minSizes = this.visManager.computeMinHeight(col);
+
+      for (const r of range) {
+        const view = await
+        col.data.idView(r);
+        (type === AColumn.DATATYPE.matrix) ? temp.push(await(<IAnyMatrix>view).nrow) : temp.push(await(<IAnyVector>view).length);
+      }
+
+      const min = minSizes;
+      const max = temp.map((d) => col.maxHeight * d);
+
+      minHeights.push(min);
+      maxHeights.push(max);
+
+      totalMax = totalMax > d3.sum(max) ? totalMax : d3.sum(max);//TODO compute properly based on visses!
+
+      index = index + 1;
+    }
+
     //choose minimal block height for each row of multiforms/stratification group
-    for (let i = 0; i < this.columns[0].multiformList.length; i++) {
+    for(let i =0; i< this.columns[0].multiformList.length; i++){
       let minSize = [];
       minHeights.forEach((m) => {
         minSize.push(m[i]);
@@ -432,99 +421,37 @@ calColHeight(height)
       });
       totalMin = totalMin + min;
     }
+
+    let totalHeight = height < totalMin ? totalMin : height;
+
+    minHeights = minHeights.map((d, i) => {
+      const minScale = d3.scale.linear().domain([0, d3.sum(d)]).range([0, totalHeight]);
+      let h = d3.sum(d.map((e) => minScale(e)));
+      return d.map((e) => minScale(e));
+    });
+
+
+    maxHeights = maxHeights.map((d, i) => {
+      const maxScale = d3.scale.linear().domain([0, d3.sum(d)]).range([0, totalMax]);
+      return d.map((e) => maxScale(e));
+    });
+
     if (totalMin > height) {
-      aggregationNeeded = true;
+       return minHeights;
+     } else if (totalMax > height) {
+       return minHeights;
+     } else if (totalMax < height) {
+       return maxHeights;
+     } else {
+       return minHeights;
+     }
+  }
+
+  private updateAggregationLevelForRow(rowIndex: number, aggregationType) {
+    for (const col of this.columns) {
+        VisManager.setMultiformAggregationType(col.multiformList[rowIndex].id, aggregationType);
     }
   }
-
-  /*************************************************************************/
-
-  totalMin = 0;
-  minHeights = [];
-
-
-  for (let i = 0; i < this.columns[0].multiformList.length; i++) {
-    let aggMode = aggregationNeeded ? VisManager.aggregationType.AGGREGATED : VisManager.aggregationType.UNAGGREGATED;
-    this.updateAggregationLevelForRow(i, aggMode);
-  }
-
-
-  //copute height requiremmts per column
-  for (const col of this.columns) {
-    const type = col.data.desc.type;
-    let range = this.colsWithRange.get(col.data.desc.id);
-    const temp = [];
-
-    if (range === undefined) {
-      range = this.stratifiedRanges;
-    }
-    const minSizes = this.visManager.computeMinHeight(col);
-
-    for (const r of range) {
-      const view = await
-      col.data.idView(r);
-      (type === AColumn.DATATYPE.matrix) ? temp.push(await(<IAnyMatrix>view).nrow) : temp.push(await(<IAnyVector>view).length);
-    }
-
-    const min = minSizes;
-    const max = temp.map((d) => col.maxHeight * d);
-
-    minHeights.push(min);
-    maxHeights.push(max);
-
-    totalMax = totalMax > d3.sum(max) ? totalMax : d3.sum(max);//TODO compute properly based on visses!
-
-    index = index + 1;
-  }
-
-  //choose minimal block height for each row of multiforms/stratification group
-  for (let i = 0; i < this.columns[0].multiformList.length; i++) {
-    let minSize = [];
-    minHeights.forEach((m) => {
-      minSize.push(m[i]);
-    });
-    let min = Math.max(...minSize);
-    minHeights.forEach((m) => {
-      m[i] = min;
-    });
-    totalMin = totalMin + min;
-  }
-
-  let totalHeight = height < totalMin ? totalMin : height;
-
-  minHeights = minHeights.map((d, i) => {
-    const minScale = d3.scale.linear().domain([0, d3.sum(d)]).range([0, totalHeight]);
-    let h = d3.sum(d.map((e) => minScale(e)));
-    return d.map((e) => minScale(e));
-  });
-
-
-  maxHeights = maxHeights.map((d, i) => {
-    const maxScale = d3.scale.linear().domain([0, d3.sum(d)]).range([0, totalMax]);
-    return d.map((e) => maxScale(e));
-  });
-
-  if (totalMin > height) {
-    return minHeights;
-  } else if (totalMax > height) {
-    return minHeights;
-  } else if (totalMax < height) {
-    return maxHeights;
-  } else {
-    return minHeights;
-  }
-}
-
-private
-updateAggregationLevelForRow(rowIndex
-:
-number, aggregationType
-)
-{
-  for (const col of this.columns) {
-    VisManager.setMultiformAggregationType(col.multiformList[rowIndex].id, aggregationType);
-  }
-}
 
 }
 

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -47,6 +47,8 @@ export default class ColumnManager extends EventHandler {
   private rangeList = [];
   private visManager: VisManager;
   private colsWithRange = new Map();
+  private rowCounter = 0;
+
 
   private onColumnRemoved = (event: IEvent) => this.remove(<AnyColumn>event.currentTarget);
   private onSortByColumnHeader = (event: IEvent, sortData) => this.fire(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, sortData);
@@ -238,6 +240,19 @@ export default class ColumnManager extends EventHandler {
       });
     });
   }
+
+  private buildRows(){
+
+  }
+
+  public updateAggregationType (multiformID : string){
+    this.columns.forEach((col) => {
+    //  col.multiformList.forEach(())
+
+    });
+
+  }
+
 
   /**
    * Calculate the maximum height of all column stratification areas and set it for every column

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -295,19 +295,6 @@ export default class ColumnManager extends EventHandler {
     });
   }
 
-  private buildRows(){
-
-  }
-
-  public updateAggregationType (multiformID : string){
-    this.columns.forEach((col) => {
-    //  col.multiformList.forEach(())
-
-    });
-
-  }
-
-
   /**
    * Calculate the maximum height of all column stratification areas and set it for every column
    */
@@ -329,7 +316,7 @@ export default class ColumnManager extends EventHandler {
 
     //switch all visses that can be switched to unaggregated and test if they can be shown as unaggregated
     /****************************************************************************************/
-    for(let i =0; i< VisManager.isUserSelectedUnaggregatedRow.length; i++){
+    for(let i =0; i< this.columns[0].multiformList.length; i++){
         this.updateAggregationLevelForRow(i, VisManager.aggregationType.UNAGGREGATED);
     }
 
@@ -345,7 +332,7 @@ export default class ColumnManager extends EventHandler {
 
     if(!aggregationNeeded) {
       //choose minimal block height for each row of multiforms/stratification group
-      for (let i = 0; i < VisManager.isUserSelectedUnaggregatedRow.length; i++) {
+      for (let i = 0; i < this.columns[0].multiformList.length; i++) {
         let minSize = [];
         minHeights.forEach((m) => {
           minSize.push(m[i]);
@@ -366,20 +353,12 @@ export default class ColumnManager extends EventHandler {
     totalMin = 0;
     minHeights = [];
 
-    //set the propper aggregation level
-    if(aggregationNeeded){
-      for(let i =0; i< VisManager.isUserSelectedUnaggregatedRow.length; i++){
-        if (!VisManager.isUserSelectedUnaggregatedRow[i]) {
-            this.updateAggregationLevelForRow(i, VisManager.aggregationType.AGGREGATED);
-        }else{
-            this.updateAggregationLevelForRow(i, VisManager.aggregationType.UNAGGREGATED);
-        }
-      }
-    }else{
-      for(let i =0; i< VisManager.isUserSelectedUnaggregatedRow.length; i++){
-        this.updateAggregationLevelForRow(i, VisManager.aggregationType.UNAGGREGATED);
-      }
+
+    for(let i =0; i< this.columns[0].multiformList.length; i++){
+      let aggMode = aggregationNeeded ? VisManager.aggregationType.AGGREGATED : VisManager.aggregationType.UNAGGREGATED;
+      this.updateAggregationLevelForRow(i, aggMode);
     }
+
 
     //copute height requiremmts per column
     for (const col of this.columns) {
@@ -410,7 +389,7 @@ export default class ColumnManager extends EventHandler {
     }
 
     //choose minimal block height for each row of multiforms/stratification group
-    for(let i =0; i< VisManager.isUserSelectedUnaggregatedRow.length; i++){
+    for(let i =0; i< this.columns[0].multiformList.length; i++){
       let minSize = [];
       minHeights.forEach((m) => {
         minSize.push(m[i]);

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -69,348 +69,359 @@ export default class ColumnManager extends EventHandler {
   };
 
 
-  constructor(public readonly idType: IDType, public readonly orientation: EOrientation, public readonly $parent: d3.Selection<any>) {
-    super();
-    this.build();
-    this.attachListener();
-  }
+  constructor(public readonly
 
-  private build() {
-    this.visManager = new VisManager();
+  idType: IDType
+,
+  public readonly orientation: EOrientation
+,
+  public readonly $parent: d3.Selection<any>
+) {
+  super();
 
-    this.$node = this.$parent
-      .classed('column-manager', true)
-      .append('ol')
-      .classed('columnList', true);
+  this
+.
+  build();
 
-    $('.columnList', this.$parent.node()) // jquery
-      .sortable({
-        handle: '.labelName',
-        axis: 'x',
-        items: '> :not(.nodrag)'
-      });
+  this
+.
+  attachListener();
+}
 
-    this.aggSwitcherCol = new AggSwitcherColumn(null, EOrientation.Horizontal, this.$node);
-  }
+private
+build()
+{
+  this.visManager = new VisManager();
 
-  private attachListener() {
-    on(AVectorFilter.EVENT_SORTBY_FILTER_ICON, (evt: any, sortData: {sortMethod: string, col: AFilter<string,IMotherTableType>}) => {
-      const col = this.filtersHierarchy.filter((d) => d.data.desc.id === sortData.col.data.desc.id);
-      col[0].sortCriteria = sortData.sortMethod;
-      this.updateColumns();
+  this.$node = this.$parent
+    .classed('column-manager', true)
+    .append('ol')
+    .classed('columnList', true);
+
+  $('.columnList', this.$parent.node()) // jquery
+    .sortable({
+      handle: '.labelName',
+      axis: 'x',
+      items: '> :not(.nodrag)'
     });
 
-    on(CategoricalColumn.EVENT_STRATIFYME, (evt: any, colid) => {
+  this.aggSwitcherCol = new AggSwitcherColumn(null, EOrientation.Horizontal, this.$node);
+}
 
-      const col = this.filtersHierarchy.filter((d) => d.data.desc.id === colid.data.desc.id);
-      this.stratifyColid = col[0].data.desc.id;
-      this.stratifyAndRelayout();
-    });
-
-    this.aggSwitcherCol.on(AggSwitcherColumn.EVENT_GROUP_AGG_CHANGED, (evt:any, index:number, value:AggMode, allGroups:AggMode[]) => {
-      console.log(index, value, allGroups);
-    });
-  }
-
-  get length() {
-    return this.columns.length;
-  }
-
-  destroy() {
-    // delete all columns, can't remove myself, since I'm using the parent
-    this.$parent.selectAll('.column').remove();
-  }
-
-  /**
-   * Adding a new column from given data
-   * Called when adding a new filter from dropdown or from hash
-   *
-   * @param data
-   * @returns {Promise<AnyColumn>}
-   */
-  async push(data: IMotherTableType) {
-    // if (data.idtypes[0] !== this.idType) {
-    //   throw new Error('invalid idtype');
-    // }
-    const col = createColumn(data, this.orientation, this.$node);
-
-    if (this.firstColumnRange === undefined) {
-      this.firstColumnRange = await data.ids();
-    }
-
-    col.on(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
-    col.on(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this.onSortByColumnHeader);
-    col.on(AColumn.EVENT_COLUMN_LOCK_CHANGED, this.onLockChange);
-    col.on(CategoricalColumn.EVENT_STRATIFYME, this.stratifyMe);
-    col.on(AColumn.VISUALIZATION_SWITCHED, this.onVisChange);
-
-    this.columns.push(col);
-
-    // add column to hierarchy if it isn't a matrix and already added
-    const id = this.filtersHierarchy.filter((c) => c.data.desc.id === col.data.desc.id);
-    if (col.data.desc.type !== AColumn.DATATYPE.matrix && id.length === 0) {
-      this.filtersHierarchy.push(col);
-    }
-
-    return col;
-  }
-
-  remove(col: AnyColumn) {
-    this.columns.splice(this.columns.indexOf(col), 1);
-    col.$node.remove();
-    col.off(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
-    col.off(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this.onSortByColumnHeader);
-    col.off(AColumn.EVENT_COLUMN_LOCK_CHANGED, this.onLockChange);
-    col.off(AColumn.VISUALIZATION_SWITCHED, this.onVisChange);
-    this.fire(ColumnManager.EVENT_COLUMN_REMOVED, col);
-    this.fire(ColumnManager.EVENT_DATA_REMOVED, col.data);
+private
+attachListener()
+{
+  on(AVectorFilter.EVENT_SORTBY_FILTER_ICON, (evt: any, sortData: {sortMethod: string, col: AFilter<string,IMotherTableType>}) => {
+    const col = this.filtersHierarchy.filter((d) => d.data.desc.id === sortData.col.data.desc.id);
+    col[0].sortCriteria = sortData.sortMethod;
     this.updateColumns();
+  });
+
+  on(CategoricalColumn.EVENT_STRATIFYME, (evt: any, colid) => {
+
+    const col = this.filtersHierarchy.filter((d) => d.data.desc.id === colid.data.desc.id);
+    this.stratifyColid = col[0].data.desc.id;
+    this.stratifyAndRelayout();
+  });
+
+  this.aggSwitcherCol.on(AggSwitcherColumn.EVENT_GROUP_AGG_CHANGED, (evt: any, index: number, value: AggMode, allGroups: AggMode[]) => {
+    console.log(index, value, allGroups);
+  });
+}
+
+get
+length()
+{
+  return this.columns.length;
+}
+
+destroy()
+{
+  // delete all columns, can't remove myself, since I'm using the parent
+  this.$parent.selectAll('.column').remove();
+}
+
+/**
+ * Adding a new column from given data
+ * Called when adding a new filter from dropdown or from hash
+ *
+ * @param data
+ * @returns {Promise<AnyColumn>}
+ */
+async
+push(data
+:
+IMotherTableType
+)
+{
+  // if (data.idtypes[0] !== this.idType) {
+  //   throw new Error('invalid idtype');
+  // }
+  const col = createColumn(data, this.orientation, this.$node);
+
+  if (this.firstColumnRange === undefined) {
+    this.firstColumnRange = await
+    data.ids();
   }
 
-  /**
-   * move a column at the given index
-   * @param col
-   * @param index
-   */
-  move(col: AnyColumn, index: number) {
-    const old = this.columns.indexOf(col);
-    if (old === index) {
-      return;
-    }
-    //move the dom element, too
-    this.$parent.node().insertBefore(col.$node.node(), this.$parent.node().childNodes[index]);
+  col.on(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
+  col.on(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this.onSortByColumnHeader);
+  col.on(AColumn.EVENT_COLUMN_LOCK_CHANGED, this.onLockChange);
+  col.on(CategoricalColumn.EVENT_STRATIFYME, this.stratifyMe);
+  col.on(AColumn.VISUALIZATION_SWITCHED, this.onVisChange);
 
-    this.columns.splice(old, 1);
-    if (old < index) {
-      index -= 1; //shifted because of deletion
-    }
-    this.columns.splice(index, 0, col);
-    this.relayout();
+  this.columns.push(col);
+
+  // add column to hierarchy if it isn't a matrix and already added
+  const id = this.filtersHierarchy.filter((c) => c.data.desc.id === col.data.desc.id);
+  if (col.data.desc.type !== AColumn.DATATYPE.matrix && id.length === 0) {
+    this.filtersHierarchy.push(col);
   }
 
-  /**
-   * Apply a filtered range to all columns
-   * @param idRange
-   * @returns {Promise<void>}
-   */
-  async filterData(idRange: Range) {
-    if (isNumber(idRange.ndim) !== true || idRange.size()[0] === 0) {
-      this.columns.forEach((col) => col.updateMultiForms([idRange]));
-      return;
-    }
+  return col;
+}
 
-    for (const col of this.columns) {
-      col.rangeView = idRange;
-      col.dataView = await col.data.idView(idRange);
-    }
+remove(col
+:
+AnyColumn
+)
+{
+  this.columns.splice(this.columns.indexOf(col), 1);
+  col.$node.remove();
+  col.off(AColumn.EVENT_REMOVE_ME, this.onColumnRemoved);
+  col.off(AVectorColumn.EVENT_SORTBY_COLUMN_HEADER, this.onSortByColumnHeader);
+  col.off(AColumn.EVENT_COLUMN_LOCK_CHANGED, this.onLockChange);
+  col.off(AColumn.VISUALIZATION_SWITCHED, this.onVisChange);
+  this.fire(ColumnManager.EVENT_COLUMN_REMOVED, col);
+  this.fire(ColumnManager.EVENT_DATA_REMOVED, col.data);
+  this.updateColumns();
+}
 
-    this.updateColumns();
+/**
+ * move a column at the given index
+ * @param col
+ * @param index
+ */
+move(col
+:
+AnyColumn, index
+:
+number
+)
+{
+  const old = this.columns.indexOf(col);
+  if (old === index) {
+    return;
+  }
+  //move the dom element, too
+  this.$parent.node().insertBefore(col.$node.node(), this.$parent.node().childNodes[index]);
+
+  this.columns.splice(old, 1);
+  if (old < index) {
+    index -= 1; //shifted because of deletion
+  }
+  this.columns.splice(index, 0, col);
+  this.relayout();
+}
+
+/**
+ * Apply a filtered range to all columns
+ * @param idRange
+ * @returns {Promise<void>}
+ */
+async
+filterData(idRange
+:
+Range
+)
+{
+  if (isNumber(idRange.ndim) !== true || idRange.size()[0] === 0) {
+    this.columns.forEach((col) => col.updateMultiForms([idRange]));
+    return;
   }
 
-  /**
-   * Find corresponding columns for given list of filters and update the sorted  hierarchy
-   * @param filterList
-   */
-  mapFiltersAndSort(filterList: AnyFilter[]) {
-    this.filtersHierarchy = filterList.map((d) => this.columns.filter((c) => c.data === d.data)[0]);
-    this.updateColumns();
+  for (const col of this.columns) {
+    col.rangeView = idRange;
+    col.dataView = await
+    col.data.idView(idRange);
   }
 
-  /**
-   * Sort, stratify and render all columns
-   */
-  async updateColumns() {
-    await this.sortColumns();
-    await this.stratifyAndRelayout();
+  this.updateColumns();
+}
+
+/**
+ * Find corresponding columns for given list of filters and update the sorted  hierarchy
+ * @param filterList
+ */
+mapFiltersAndSort(filterList
+:
+AnyFilter[]
+)
+{
+  this.filtersHierarchy = filterList.map((d) => this.columns.filter((c) => c.data === d.data)[0]);
+  this.updateColumns();
+}
+
+/**
+ * Sort, stratify and render all columns
+ */
+async
+updateColumns()
+{
+  await
+  this.sortColumns();
+  await
+  this.stratifyAndRelayout();
+}
+
+async
+stratifyAndRelayout()
+{
+  this.updateStratifyID(this.stratifyColid);
+  await
+  this.stratifyColumns();
+  this.relayout();
+}
+
+/**
+ * Sorting the ranges based on the filter hierarchy
+ */
+private async
+sortColumns()
+{
+  const cols = this.filtersHierarchy;
+
+  //special handling if matrix is added as first column
+  if (cols.length === 0) {
+    this.nonStratifiedRange = this.firstColumnRange;
+    this.stratifiedRanges = [this.firstColumnRange];
+    return;
   }
 
-  async stratifyAndRelayout() {
-    this.updateStratifyID(this.stratifyColid);
-    await this.stratifyColumns();
-    this.relayout();
+  // The sort object is created on the fly and destroyed after it exits this method
+  const s = new SortHandler();
+  const r = await
+  s.sortColumns(cols);
+  this.nonStratifiedRange = r.combined;
+  this.stratifiedRanges = [r.combined];
+  this.dataPerStratificaiton = r.stratified;
+  cols.forEach((col) => {
+    this.colsWithRange.set(col.data.desc.id, [this.nonStratifiedRange]);
+  });
+
+  const categoricalCol = cols.filter((c) => c.data.desc.value.type === VALUE_TYPE_CATEGORICAL);
+  if (categoricalCol.length > 0 && this.stratifyColid === undefined) {
+    this.stratifyColid = categoricalCol[0].data.desc.id;
+  }
+}
+
+private async
+updateStratifyID(colid)
+{
+  if (colid === undefined) {
+    return;
   }
 
-  /**
-   * Sorting the ranges based on the filter hierarchy
-   */
-  private async sortColumns() {
-    const cols = this.filtersHierarchy;
+  this.stratifyColid = colid;
+  const cols = this.filtersHierarchy;
+  const datas = this.dataPerStratificaiton.get(colid);
+  const prepareRange = prepareRangeFromList(makeListFromRange(this.nonStratifiedRange), [datas]);
+  this.stratifiedRanges = prepareRange[0].map((d) => makeRangeFromList(d));
+  cols.forEach((col) => {
+    this.colsWithRange.set(col.data.desc.id, this.stratifiedRanges);
+  });
+}
 
-    //special handling if matrix is added as first column
-    if (cols.length === 0) {
-      this.nonStratifiedRange = this.firstColumnRange;
-      this.stratifiedRanges = [this.firstColumnRange];
-      return;
-    }
+/**
+ *
+ * @param idRange
+ * @returns {Promise<void>}
+ */
+private async
+stratifyColumns()
+{
+  const vectorCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.vector);
+  vectorCols.forEach((col) => {
+    const r = this.colsWithRange.get(col.data.desc.id);
+    col.updateMultiForms(r);
+  });
 
-    // The sort object is created on the fly and destroyed after it exits this method
-    const s = new SortHandler();
-    const r = await s.sortColumns(cols);
-    this.nonStratifiedRange = r.combined;
-    this.stratifiedRanges = [r.combined];
-    this.dataPerStratificaiton = r.stratified;
-    cols.forEach((col) => {
-      this.colsWithRange.set(col.data.desc.id, [this.nonStratifiedRange]);
+  // update matrix column with last sorted range
+  const matrixCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.matrix);
+  matrixCols.map((col) => col.updateMultiForms(this.stratifiedRanges));
+
+  // update aggregation switcher column
+  this.aggSwitcherCol.updateMultiForms(this.stratifiedRanges);
+}
+
+async
+relayout()
+{
+  await
+  resolveIn(10);
+  this.relayoutColStrats();
+  const header = 47;//TODO solve programatically
+  const height = Math.min(...this.columns.map((c) => c.$node.property('clientHeight') - header));
+  const rowHeight = await
+  this.calColHeight(height);
+  const colWidths = distributeColWidths(this.columns, this.$parent.property('clientWidth'));
+
+  if (this.columns.length > 0) {
+    this.aggSwitcherCol.updateSwitcherBlocks(this.columns[0].multiformList.map((d, i) => rowHeight[0][i]));
+  }
+
+  this.columns.forEach((col, i) => {
+    col.$node.style('width', colWidths[i] + 'px');
+
+    col.multiformList.forEach((multiform, index) => {
+      this.visManager.assignVis(multiform, colWidths[i], rowHeight[i][index]);
+      scaleTo(multiform, colWidths[i], rowHeight[i][index], col.orientation);
     });
+  });
+}
 
-    const categoricalCol = cols.filter((c) => c.data.desc.value.type === VALUE_TYPE_CATEGORICAL);
-    if (categoricalCol.length > 0 && this.stratifyColid === undefined) {
-      this.stratifyColid = categoricalCol[0].data.desc.id;
-    }
+/**
+ * Calculate the maximum height of all column stratification areas and set it for every column
+ */
+private
+relayoutColStrats()
+{
+  const $strats = this.$node.selectAll('aside')
+    .style('height', null); // remove height first, to calculate a new one
+  const maxHeight = Math.max(...$strats[0].map((d: HTMLElement) => d.clientHeight));
+  $strats.style('height', maxHeight + 'px');
+}
+
+private async
+calColHeight(height)
+{
+  let ranges = [];
+  let minHeights = [];
+  let maxHeights = [];
+  let index = 0;
+  let totalMin = 0;
+  let totalMax = 0;
+
+
+  //switch all visses that can be switched to unaggregated and test if they can be shown as unaggregated
+  /****************************************************************************************/
+  for (let i = 0; i < this.columns[0].multiformList.length; i++) {
+    this.updateAggregationLevelForRow(i, VisManager.aggregationType.UNAGGREGATED);
   }
 
-  private async updateStratifyID(colid) {
-    if (colid === undefined) {
-      return;
+  //first run - check if the unagregatted columns fit and if not, switch all non-user-unaggregated rows to aggregated
+  let aggregationNeeded = false;
+  for (const col of this.columns) {
+    const minSizes = this.visManager.computeMinHeight(col);
+    if (d3.sum(minSizes) > height) {
+      aggregationNeeded = true;
     }
-
-    this.stratifyColid = colid;
-    const cols = this.filtersHierarchy;
-    const datas = this.dataPerStratificaiton.get(colid);
-    const prepareRange = prepareRangeFromList(makeListFromRange(this.nonStratifiedRange), [datas]);
-    this.stratifiedRanges = prepareRange[0].map((d) => makeRangeFromList(d));
-    cols.forEach((col) => {
-      this.colsWithRange.set(col.data.desc.id, this.stratifiedRanges);
-    });
+    minHeights.push(minSizes);
   }
 
-  /**
-   *
-   * @param idRange
-   * @returns {Promise<void>}
-   */
-  private async stratifyColumns() {
-    const vectorCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.vector);
-    vectorCols.forEach((col) => {
-      const r = this.colsWithRange.get(col.data.desc.id);
-      col.updateMultiForms(r);
-    });
-
-    // update matrix column with last sorted range
-    const matrixCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.matrix);
-    matrixCols.map((col) => col.updateMultiForms(this.stratifiedRanges));
-
-    // update aggregation switcher column
-    this.aggSwitcherCol.updateMultiForms(this.stratifiedRanges);
-  }
-
-  async relayout() {
-    await resolveIn(10);
-    this.relayoutColStrats();
-    const header = 47;//TODO solve programatically
-    const height = Math.min(...this.columns.map((c) => c.$node.property('clientHeight') - header));
-    const rowHeight = await this.calColHeight(height);
-    const colWidths = distributeColWidths(this.columns, this.$parent.property('clientWidth'));
-
-    if(this.columns.length > 0) {
-      this.aggSwitcherCol.updateSwitcherBlocks(this.columns[0].multiformList.map((d, i) => rowHeight[0][i]));
-    }
-
-    this.columns.forEach((col, i) => {
-      col.$node.style('width', colWidths[i] + 'px');
-
-      col.multiformList.forEach((multiform, index) => {
-        this.visManager.assignVis(multiform, colWidths[i], rowHeight[i][index]);
-        scaleTo(multiform, colWidths[i], rowHeight[i][index], col.orientation);
-      });
-    });
-  }
-
-  /**
-   * Calculate the maximum height of all column stratification areas and set it for every column
-   */
-  private relayoutColStrats() {
-    const $strats = this.$node.selectAll('aside')
-      .style('height', null); // remove height first, to calculate a new one
-    const maxHeight = Math.max(...$strats[0].map((d: HTMLElement) => d.clientHeight));
-    $strats.style('height', maxHeight + 'px');
-  }
-
-  private async calColHeight(height) {
-    let ranges = [];
-    let minHeights = [];
-    let maxHeights = [];
-    let index = 0;
-    let totalMin = 0;
-    let totalMax = 0;
-
-
-    //switch all visses that can be switched to unaggregated and test if they can be shown as unaggregated
-    /****************************************************************************************/
-    for(let i =0; i< this.columns[0].multiformList.length; i++){
-        this.updateAggregationLevelForRow(i, VisManager.aggregationType.UNAGGREGATED);
-    }
-
-    //first run - check if the unagregatted columns fit and if not, switch all non-user-unaggregated rows to aggregated
-    let aggregationNeeded = false;
-    for (const col of this.columns) {
-      const minSizes = this.visManager.computeMinHeight(col);
-      if (d3.sum(minSizes) > height) {
-        aggregationNeeded = true;
-      }
-      minHeights.push(minSizes);
-    }
-
-    if(!aggregationNeeded) {
-      //choose minimal block height for each row of multiforms/stratification group
-      for (let i = 0; i < this.columns[0].multiformList.length; i++) {
-        let minSize = [];
-        minHeights.forEach((m) => {
-          minSize.push(m[i]);
-        });
-        let min = Math.max(...minSize);
-        minHeights.forEach((m) => {
-          m[i] = min;
-        });
-        totalMin = totalMin + min;
-      }
-      if(totalMin > height){
-        aggregationNeeded = true;
-      }
-    }
-
-    /*************************************************************************/
-
-    totalMin = 0;
-    minHeights = [];
-
-
-    for(let i =0; i< this.columns[0].multiformList.length; i++){
-      let aggMode = aggregationNeeded ? VisManager.aggregationType.AGGREGATED : VisManager.aggregationType.UNAGGREGATED;
-      this.updateAggregationLevelForRow(i, aggMode);
-    }
-
-
-    //copute height requiremmts per column
-    for (const col of this.columns) {
-      const type = col.data.desc.type;
-      let range = this.colsWithRange.get(col.data.desc.id);
-      const temp = [];
-
-      if (range === undefined) {
-        range = this.stratifiedRanges;
-      }
-      const minSizes = this.visManager.computeMinHeight(col);
-
-      for (const r of range) {
-        const view = await
-        col.data.idView(r);
-        (type === AColumn.DATATYPE.matrix) ? temp.push(await(<IAnyMatrix>view).nrow) : temp.push(await(<IAnyVector>view).length);
-      }
-
-      const min = minSizes;
-      const max = temp.map((d) => col.maxHeight * d);
-
-      minHeights.push(min);
-      maxHeights.push(max);
-
-      totalMax = totalMax > d3.sum(max) ? totalMax : d3.sum(max);//TODO compute properly based on visses!
-
-      index = index + 1;
-    }
-
+  if (!aggregationNeeded) {
     //choose minimal block height for each row of multiforms/stratification group
-    for(let i =0; i< this.columns[0].multiformList.length; i++){
+    for (let i = 0; i < this.columns[0].multiformList.length; i++) {
       let minSize = [];
       minHeights.forEach((m) => {
         minSize.push(m[i]);
@@ -421,37 +432,99 @@ export default class ColumnManager extends EventHandler {
       });
       totalMin = totalMin + min;
     }
-
-    let totalHeight = height < totalMin ? totalMin : height;
-
-    minHeights = minHeights.map((d, i) => {
-      const minScale = d3.scale.linear().domain([0, d3.sum(d)]).range([0, totalHeight]);
-      let h = d3.sum(d.map((e) => minScale(e)));
-      return d.map((e) => minScale(e));
-    });
-
-
-    maxHeights = maxHeights.map((d, i) => {
-      const maxScale = d3.scale.linear().domain([0, d3.sum(d)]).range([0, totalMax]);
-      return d.map((e) => maxScale(e));
-    });
-
     if (totalMin > height) {
-       return minHeights;
-     } else if (totalMax > height) {
-       return minHeights;
-     } else if (totalMax < height) {
-       return maxHeights;
-     } else {
-       return minHeights;
-     }
-  }
-
-  private updateAggregationLevelForRow(rowIndex: number, aggregationType) {
-    for (const col of this.columns) {
-        VisManager.setMultiformAggregationType(col.multiformList[rowIndex].id, aggregationType);
+      aggregationNeeded = true;
     }
   }
+
+  /*************************************************************************/
+
+  totalMin = 0;
+  minHeights = [];
+
+
+  for (let i = 0; i < this.columns[0].multiformList.length; i++) {
+    let aggMode = aggregationNeeded ? VisManager.aggregationType.AGGREGATED : VisManager.aggregationType.UNAGGREGATED;
+    this.updateAggregationLevelForRow(i, aggMode);
+  }
+
+
+  //copute height requiremmts per column
+  for (const col of this.columns) {
+    const type = col.data.desc.type;
+    let range = this.colsWithRange.get(col.data.desc.id);
+    const temp = [];
+
+    if (range === undefined) {
+      range = this.stratifiedRanges;
+    }
+    const minSizes = this.visManager.computeMinHeight(col);
+
+    for (const r of range) {
+      const view = await
+      col.data.idView(r);
+      (type === AColumn.DATATYPE.matrix) ? temp.push(await(<IAnyMatrix>view).nrow) : temp.push(await(<IAnyVector>view).length);
+    }
+
+    const min = minSizes;
+    const max = temp.map((d) => col.maxHeight * d);
+
+    minHeights.push(min);
+    maxHeights.push(max);
+
+    totalMax = totalMax > d3.sum(max) ? totalMax : d3.sum(max);//TODO compute properly based on visses!
+
+    index = index + 1;
+  }
+
+  //choose minimal block height for each row of multiforms/stratification group
+  for (let i = 0; i < this.columns[0].multiformList.length; i++) {
+    let minSize = [];
+    minHeights.forEach((m) => {
+      minSize.push(m[i]);
+    });
+    let min = Math.max(...minSize);
+    minHeights.forEach((m) => {
+      m[i] = min;
+    });
+    totalMin = totalMin + min;
+  }
+
+  let totalHeight = height < totalMin ? totalMin : height;
+
+  minHeights = minHeights.map((d, i) => {
+    const minScale = d3.scale.linear().domain([0, d3.sum(d)]).range([0, totalHeight]);
+    let h = d3.sum(d.map((e) => minScale(e)));
+    return d.map((e) => minScale(e));
+  });
+
+
+  maxHeights = maxHeights.map((d, i) => {
+    const maxScale = d3.scale.linear().domain([0, d3.sum(d)]).range([0, totalMax]);
+    return d.map((e) => maxScale(e));
+  });
+
+  if (totalMin > height) {
+    return minHeights;
+  } else if (totalMax > height) {
+    return minHeights;
+  } else if (totalMax < height) {
+    return maxHeights;
+  } else {
+    return minHeights;
+  }
+}
+
+private
+updateAggregationLevelForRow(rowIndex
+:
+number, aggregationType
+)
+{
+  for (const col of this.columns) {
+    VisManager.setMultiformAggregationType(col.multiformList[rowIndex].id, aggregationType);
+  }
+}
 
 }
 

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -295,19 +295,6 @@ export default class ColumnManager extends EventHandler {
     });
   }
 
-  private buildRows(){
-
-  }
-
-  public updateAggregationType (multiformID : string){
-    this.columns.forEach((col) => {
-    //  col.multiformList.forEach(())
-
-    });
-
-  }
-
-
   /**
    * Calculate the maximum height of all column stratification areas and set it for every column
    */
@@ -452,7 +439,6 @@ export default class ColumnManager extends EventHandler {
         VisManager.setMultiformAggregationType(col.multiformList[rowIndex].id, aggregationType);
     }
   }
-
 }
 
 

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -275,7 +275,6 @@ export default class ColumnManager extends EventHandler {
     const matrixCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.matrix);
     matrixCols.map((col) => col.updateMultiForms(this.stratifiedRanges));
 
-
   }
 
   async relayout() {

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -47,7 +47,7 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
 
   protected multiFormParams(): IMultiFormOptions {
     return {
-      initialVis: VisManager.getDefaultVis(this.data.desc.type, this.data.desc.value.type),
+      initialVis: VisManager.getDefaultVis(this.data.desc.type, this.data.desc.value.type,VisManager.aggregationType.UNAGGREGATED),
       'phovea-vis-heatmap': {
         color: NUMERICAL_COLOR_MAP
       }

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -13,7 +13,6 @@ import {createColumn, AnyColumn, IMotherTableType} from './ColumnManager';
 import * as d3 from 'd3';
 import VisManager from './VisManager';
 import AColumnManager from './AColumnManager';
-import Range1D from 'phovea_core/src/range/Range1D';
 import {AnyFilter} from '../filter/AFilter';
 
 export default class MatrixColumn extends AColumn<number, INumericalMatrix> {

--- a/src/column/NumberColumn.ts
+++ b/src/column/NumberColumn.ts
@@ -7,7 +7,6 @@ import {INumericalVector} from 'phovea_core/src/vector';
 import {IMultiFormOptions} from 'phovea_core/src/multiform';
 import {EOrientation} from './AColumn';
 import {mixin} from 'phovea_core/src/index';
-import NumberFilter from '../filter/NumberFilter';
 import {NUMERICAL_COLOR_MAP} from './utils';
 import VisManager from './VisManager';
 

--- a/src/column/NumberColumn.ts
+++ b/src/column/NumberColumn.ts
@@ -15,7 +15,7 @@ export default class NumberColumn extends AVectorColumn<number, INumericalVector
   minWidth: number = 2;
   maxWidth: number = 200;
   minHeight: number = 2;
-  maxHeight: number = 10;
+  maxHeight: number = 25;
 
   constructor(data: INumericalVector, orientation: EOrientation, $parent: d3.Selection<any>) {
     super(data, orientation);

--- a/src/column/NumberColumn.ts
+++ b/src/column/NumberColumn.ts
@@ -24,7 +24,7 @@ export default class NumberColumn extends AVectorColumn<number, INumericalVector
 
   protected multiFormParams($body: d3.Selection<any>, domain?: number[]): IMultiFormOptions {
     return mixin(super.multiFormParams($body), {
-      initialVis: VisManager.getDefaultVis(this.data.desc.type, this.data.desc.value.type),
+      initialVis: VisManager.getDefaultVis(this.data.desc.type, this.data.desc.value.type,VisManager.aggregationType.UNAGGREGATED),
       'phovea-vis-heatmap1d': {
         color: NUMERICAL_COLOR_MAP
       },

--- a/src/column/StringColumn.ts
+++ b/src/column/StringColumn.ts
@@ -21,7 +21,7 @@ export default class StringColumn extends AVectorColumn<string, IStringVector> {
 
   protected multiFormParams($body: d3.Selection<any>): IMultiFormOptions {
     return mixin(super.multiFormParams($body), {
-      initialVis: VisManager.getDefaultVis(this.data.desc.type, this.data.desc.value.type),
+      initialVis: VisManager.getDefaultVis(this.data.desc.type, this.data.desc.value.type,VisManager.aggregationType.UNAGGREGATED),
       'list': {
         cssClass: 'taggle-vis-list'
       }

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -235,7 +235,7 @@ export default class VisManager {
   }
 
   static setUserVis(id:number, vis:IVisPluginDesc, aggregationType) {
-    if(aggregationType === VisManager.aggregationType.AGGREGATED){
+    if(aggregationType == VisManager.aggregationType.AGGREGATED){
       VisManager.userSelectedAggregatedVisses[id] = vis;
     }else{
       VisManager.userSelectedUnaggregatedVisses[id] = vis;
@@ -266,10 +266,10 @@ export default class VisManager {
     col.multiformList.forEach((multiform, index) => {
       let minHeight;
       if(multiform.id in VisManager.userSelectedAggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.AGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedAggregatedVisses[multiform.id].id, multiform.data.dim)[1];
       }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.UNAGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedUnaggregatedVisses[multiform.id].id, multiform.data.dim)[1];
       }else{
         minHeight = Number.POSITIVE_INFINITY;
@@ -336,14 +336,23 @@ export default class VisManager {
 
   assignVis(multiform: MultiForm, width: number, height: number) {
     if(multiform.id in VisManager.userSelectedAggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.AGGREGATED) {
       multiform.switchTo(VisManager.userSelectedAggregatedVisses[multiform.id]);
     }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.UNAGGREGATED) {
        multiform.switchTo(VisManager.userSelectedUnaggregatedVisses[multiform.id]);
     }else{
       let preferredVis = VisManager.getDefaultVis(multiform.data.desc.type, multiform.data.desc.value.type,VisManager.multiformAggregationType[multiform.id]);
       let minPreferredSize = this.minVisSize(preferredVis, multiform.data.dim);
+
+      if (!((minPreferredSize[1] <= height) && (minPreferredSize[0] <= width))) {
+        if(VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.AGGREGATED) {
+          //choose smaller agggreg vis
+        }
+        if(VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.UNAGGREGATED) {
+          //choose smaller nonaggre vis vis
+        }
+      }
       multiform.switchTo(preferredVis);
     }
   }

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -266,10 +266,10 @@ export default class VisManager {
     col.multiformList.forEach((multiform, index) => {
       let minHeight;
       if(multiform.id in VisManager.userSelectedAggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.AGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedAggregatedVisses[multiform.id].id, multiform.data.dim)[1];
       }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.UNAGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedUnaggregatedVisses[multiform.id].id, multiform.data.dim)[1];
       }else{
         minHeight = Number.POSITIVE_INFINITY;
@@ -336,20 +336,20 @@ export default class VisManager {
 
   assignVis(multiform: MultiForm, width: number, height: number) {
     if(multiform.id in VisManager.userSelectedAggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.AGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
       multiform.switchTo(VisManager.userSelectedAggregatedVisses[multiform.id]);
     }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.UNAGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
        multiform.switchTo(VisManager.userSelectedUnaggregatedVisses[multiform.id]);
     }else{
       let preferredVis = VisManager.getDefaultVis(multiform.data.desc.type, multiform.data.desc.value.type,VisManager.multiformAggregationType[multiform.id]);
       let minPreferredSize = this.minVisSize(preferredVis, multiform.data.dim);
 
       if (!((minPreferredSize[1] <= height) && (minPreferredSize[0] <= width))) {
-        if(VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.AGGREGATED) {
+        if(VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
           //choose smaller agggreg vis
         }
-        if(VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.UNAGGREGATED) {
+        if(VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
           //choose smaller nonaggre vis vis
         }
       }

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -126,7 +126,7 @@ export default class VisManager {
    */
   public static userSelectedAggregatedVisses: {[id : string]: IVisPluginDesc} = {};
   public static userSelectedUnaggregatedVisses: {[id : string]: IVisPluginDesc} = {};
-  public static isUserSelectedUnaggregatedRow = [false];
+  public static isUserSelectedUnaggregatedRow = [];
   public static multiformAggregationType: {[id : string]: any} = {};
 
   public static aggregationType = {

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -67,25 +67,31 @@ export default class VisManager {
   };
   private readonly barplotOptions: VisOptions = {
     rowMinHeight: 2,
-    rowMaxHeight: 10,
+    rowMaxHeight: 25,
     minWidth: 40,
     maxWidth: 50
   };
   private readonly heatmap1DOptions: VisOptions = {
     rowMinHeight: 2,
-    rowMaxHeight: 10,
+    rowMaxHeight: 25,
     minWidth: 20,
     maxWidth: 50
   };
   private readonly heatmapOptions: VisOptions = {
     rowMinHeight: 2,
-    rowMaxHeight: 10,
+    rowMaxHeight: 25,
     columnMinWidth: 2,
     columnMaxWidth: 10
   };
   private readonly boxplotOptions: VisOptions = {
     minHeight: 10,
     maxHeight: 50,
+    minWidth: 20,
+    maxWidth: 50
+  };
+  private readonly propSymbolOptions: VisOptions = {
+    rowMinHeight: 10,
+    rowMaxHeight: 25,
     minWidth: 20,
     maxWidth: 50
   };
@@ -97,7 +103,7 @@ export default class VisManager {
   };
   private readonly mosaicOptions: VisOptions = {
     rowMinHeight: 2,
-    rowMaxHeight: 10,
+    rowMaxHeight: 25,
     minWidth: 20,
     maxWidth: 50
   };
@@ -118,7 +124,8 @@ export default class VisManager {
       'phovea-vis-heatmap': this.heatmapOptions,
       'phovea-vis-histogram': this.histogramOptions,
       'phovea-vis-mosaic': this.mosaicOptions,
-      'phovea-vis-box': this.boxplotOptions
+      'phovea-vis-box': this.boxplotOptions,
+      'proportionalSymbol' : this.propSymbolOptions
     };
   }
 
@@ -133,12 +140,12 @@ export default class VisManager {
           case VALUE_TYPE_CATEGORICAL:
             return 'phovea-vis-heatmap1d';
           default:
-            return 'table';
+            return 'list';
         }
       case 'matrix':
         return 'phovea-vis-heatmap';
       default:
-        return 'table'
+        return 'list'
     }
   }
 
@@ -174,7 +181,6 @@ export default class VisManager {
           let minHeightTmp = this.minVisSize(v.id,multiform.data.dim)[1];
           minHeight = (minHeight > minHeightTmp) ? minHeightTmp : minHeight;
         });
-
       }
       minColumnHeight.push(minHeight);
     });
@@ -255,7 +261,7 @@ export default class VisManager {
                     }
                   break;
                 default:
-                  visId = 'table';
+                  visId = 'list';
                   break;
             }
             break;
@@ -263,7 +269,7 @@ export default class VisManager {
               visId = 'phovea-vis-heatmap';
               break;
             default:
-              visId = 'table';
+              visId = 'list';
               break;
     }
 

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -111,7 +111,7 @@ export default class VisManager {
   private readonly vissesOptions: {[id: string]: VisOptions};
 
   public static aggregatedNumVisses = ['phovea-vis-histogram', 'phovea-vis-box'];
-  public static unaggregatedNumVisses = ['barplot','proportionalSymbol','phovea-vis-heatmap1d','list'];
+  public static unaggregatedNumVisses = ['barplot', 'proportionalSymbol', 'phovea-vis-heatmap1d', 'list'];
   public static aggregatedCatVisses = ['phovea-vis-histogram'];
   public static unaggregatedCatVisses = ['phovea-vis-heatmap1d'];
   public static aggregatedStrVisses = ['list'];//TODO change to empty vis
@@ -124,13 +124,13 @@ export default class VisManager {
   /**
    *User selected visualization for multiform with given id
    */
-  public static userSelectedAggregatedVisses: {[id : string]: IVisPluginDesc} = {};
-  public static userSelectedUnaggregatedVisses: {[id : string]: IVisPluginDesc} = {};
-  public static multiformAggregationType: {[id : string]: any} = {};
+  public static userSelectedAggregatedVisses: {[id: string]: IVisPluginDesc} = {};
+  public static userSelectedUnaggregatedVisses: {[id: string]: IVisPluginDesc} = {};
+  public static multiformAggregationType: {[id: string]: any} = {};
 
   public static aggregationType = {
-    AGGREGATED : 1,
-    UNAGGREGATED : 2,
+    AGGREGATED: 1,
+    UNAGGREGATED: 2,
   };
 
   constructor() {
@@ -143,14 +143,14 @@ export default class VisManager {
       'phovea-vis-histogram': this.histogramOptions,
       'phovea-vis-mosaic': this.mosaicOptions,
       'phovea-vis-box': this.boxplotOptions,
-      'proportionalSymbol' : this.propSymbolOptions
+      'proportionalSymbol': this.propSymbolOptions
     };
   }
 
-  static getDefaultVis(columnType: string, dataType: string, aggregationType ) {
-    switch(aggregationType){
+  static getDefaultVis(columnType: string, dataType: string, aggregationType) {
+    switch (aggregationType) {
       case VisManager.aggregationType.AGGREGATED:
-        switch(columnType){
+        switch (columnType) {
           case 'vector':
             switch (dataType) {
               case VALUE_TYPE_STRING:
@@ -168,7 +168,7 @@ export default class VisManager {
             return 'list'
         }
       case VisManager.aggregationType.UNAGGREGATED:
-        switch(columnType){
+        switch (columnType) {
           case 'vector':
             switch (dataType) {
               case VALUE_TYPE_STRING:
@@ -188,10 +188,10 @@ export default class VisManager {
     }
   }
 
-  static getPossibleVisses(columnType: string, dataType: string, aggregationType ) {
-    switch(aggregationType){
+  static getPossibleVisses(columnType: string, dataType: string, aggregationType) {
+    switch (aggregationType) {
       case VisManager.aggregationType.AGGREGATED:
-        switch(columnType){
+        switch (columnType) {
           case 'vector':
             switch (dataType) {
               case VALUE_TYPE_STRING:
@@ -204,12 +204,12 @@ export default class VisManager {
                 return;
             }
           case 'matrix':
-            return  VisManager.unaggregatedNumMatVisses;
+            return VisManager.unaggregatedNumMatVisses;
           default:
             return
         }
       case VisManager.aggregationType.UNAGGREGATED:
-        switch(columnType){
+        switch (columnType) {
           case 'vector':
             switch (dataType) {
               case VALUE_TYPE_STRING:
@@ -222,35 +222,35 @@ export default class VisManager {
                 return;
             }
           case 'matrix':
-            return  VisManager.unaggregatedNumMatVisses;
+            return VisManager.unaggregatedNumMatVisses;
           default:
             return
         }
     }
   }
 
-  static setMultiformAggregationType(id:string, aggregationType){
+  static setMultiformAggregationType(id: string, aggregationType) {
     VisManager.multiformAggregationType[id] = aggregationType;
   }
 
-  static setUserVis(id:number, vis:IVisPluginDesc, aggregationType) {
-    if(aggregationType == VisManager.aggregationType.AGGREGATED){
+  static setUserVis(id: number, vis: IVisPluginDesc, aggregationType) {
+    if (aggregationType == VisManager.aggregationType.AGGREGATED) {
       VisManager.userSelectedAggregatedVisses[id] = vis;
-    }else{
+    } else {
       VisManager.userSelectedUnaggregatedVisses[id] = vis;
     }
   }
 
-  static updateUserVis(idOld:string, idNew:string) {
-    if(idOld in VisManager.userSelectedAggregatedVisses) {
+  static updateUserVis(idOld: string, idNew: string) {
+    if (idOld in VisManager.userSelectedAggregatedVisses) {
       VisManager.userSelectedAggregatedVisses[idNew] = VisManager.userSelectedAggregatedVisses[idOld];
     }
-    if(idOld in VisManager.userSelectedUnaggregatedVisses) {
+    if (idOld in VisManager.userSelectedUnaggregatedVisses) {
       VisManager.userSelectedUnaggregatedVisses[idNew] = VisManager.userSelectedUnaggregatedVisses[idOld];
     }
   }
 
-  static removeUserVisses(id:string) {
+  static removeUserVisses(id: string) {
     delete VisManager.userSelectedAggregatedVisses[id];
     delete VisManager.userSelectedUnaggregatedVisses[id];
   }
@@ -264,13 +264,13 @@ export default class VisManager {
     let minColumnHeight: number[] = [];
     col.multiformList.forEach((multiform, index) => {
       let minHeight;
-      if(multiform.id in VisManager.userSelectedAggregatedVisses
+      if (multiform.id in VisManager.userSelectedAggregatedVisses
         && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedAggregatedVisses[multiform.id].id, multiform.data.dim)[1];
-      }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
+      } else if (multiform.id in VisManager.userSelectedUnaggregatedVisses
         && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedUnaggregatedVisses[multiform.id].id, multiform.data.dim)[1];
-      }else{
+      } else {
         minHeight = Number.POSITIVE_INFINITY;
         let visses = VisManager.getPossibleVisses(multiform.data.desc.type, multiform.data.desc.value.type, VisManager.multiformAggregationType[multiform.id]);
         visses.forEach((v) => {
@@ -334,14 +334,14 @@ export default class VisManager {
 
 
   assignVis(multiform: MultiForm, width: number, height: number) {
-    if(multiform.id in VisManager.userSelectedAggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
+    if (multiform.id in VisManager.userSelectedAggregatedVisses
+      && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
       multiform.switchTo(VisManager.userSelectedAggregatedVisses[multiform.id]);
-    }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
-       multiform.switchTo(VisManager.userSelectedUnaggregatedVisses[multiform.id]);
-    }else{
-      let preferredVis = VisManager.getDefaultVis(multiform.data.desc.type, multiform.data.desc.value.type,VisManager.multiformAggregationType[multiform.id]);
+    } else if (multiform.id in VisManager.userSelectedUnaggregatedVisses
+      && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
+      multiform.switchTo(VisManager.userSelectedUnaggregatedVisses[multiform.id]);
+    } else {
+      let preferredVis = VisManager.getDefaultVis(multiform.data.desc.type, multiform.data.desc.value.type, VisManager.multiformAggregationType[multiform.id]);
       multiform.switchTo(preferredVis);
     }
   }

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -107,7 +107,7 @@ export default class VisManager {
   /**
    *User selected visualization for multiform with given id
    */
-  public static userSelectedVisses: {[id : number] : IVisPluginDesc} = {};
+  public static userSelectedVisses: {[id : string] : IVisPluginDesc} = {};
 
   constructor(){
     this.vissesOptions = {
@@ -146,8 +146,14 @@ export default class VisManager {
       VisManager.userSelectedVisses[id] = vis;
   }
 
-  static updateUserVis(idOld:number, idNew:number) {
+  static updateUserVis(idOld:string, idNew:string) {
+    if(idOld in VisManager.userSelectedVisses) {
       VisManager.userSelectedVisses[idNew] = VisManager.userSelectedVisses[idOld];
+    }
+  }
+
+  static removeUserVis(id:string) {
+    delete VisManager.userSelectedVisses[id];
   }
 
   /*

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -3,7 +3,7 @@
  */
 import MultiForm from 'phovea_core/src/multiform/MultiForm';
 import {IVisPluginDesc} from 'phovea_core/src/vis';
-import {IMotherTableType, AnyColumn} from './ColumnManager';
+import {AnyColumn} from './ColumnManager';
 
 import {
   VALUE_TYPE_CATEGORICAL, VALUE_TYPE_INT, VALUE_TYPE_REAL,

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -126,7 +126,6 @@ export default class VisManager {
    */
   public static userSelectedAggregatedVisses: {[id : string]: IVisPluginDesc} = {};
   public static userSelectedUnaggregatedVisses: {[id : string]: IVisPluginDesc} = {};
-  public static isUserSelectedUnaggregatedRow = [];
   public static multiformAggregationType: {[id : string]: any} = {};
 
   public static aggregationType = {
@@ -343,16 +342,6 @@ export default class VisManager {
        multiform.switchTo(VisManager.userSelectedUnaggregatedVisses[multiform.id]);
     }else{
       let preferredVis = VisManager.getDefaultVis(multiform.data.desc.type, multiform.data.desc.value.type,VisManager.multiformAggregationType[multiform.id]);
-      let minPreferredSize = this.minVisSize(preferredVis, multiform.data.dim);
-
-      if (!((minPreferredSize[1] <= height) && (minPreferredSize[0] <= width))) {
-        if(VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
-          //choose smaller agggreg vis
-        }
-        if(VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
-          //choose smaller nonaggre vis vis
-        }
-      }
       multiform.switchTo(preferredVis);
     }
   }

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -325,6 +325,10 @@ export default class VisManager {
         minVisHeight = dims[0] * this.vissesOptions[vis].rowMinHeight;
         minVisWidth = this.vissesOptions[vis].minWidth;
         break;
+      case('proportionalSymbol'):
+        minVisHeight = dims[0] * this.vissesOptions[vis].rowMinHeight;
+        minVisWidth = this.vissesOptions[vis].minWidth;
+        break;
       default:
         minVisHeight = 50;
         minVisWidth = 20;

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -111,7 +111,7 @@ export default class VisManager {
   private readonly vissesOptions: {[id: string]: VisOptions};
 
   public static aggregatedNumVisses = ['phovea-vis-histogram', 'phovea-vis-box'];
-  public static unaggregatedNumVisses = ['barplot', 'proportionalSymbol', 'phovea-vis-heatmap1d', 'list'];
+  public static unaggregatedNumVisses = ['barplot','proportionalSymbol','phovea-vis-heatmap1d','list'];
   public static aggregatedCatVisses = ['phovea-vis-histogram'];
   public static unaggregatedCatVisses = ['phovea-vis-heatmap1d'];
   public static aggregatedStrVisses = ['list'];//TODO change to empty vis
@@ -124,13 +124,13 @@ export default class VisManager {
   /**
    *User selected visualization for multiform with given id
    */
-  public static userSelectedAggregatedVisses: {[id: string]: IVisPluginDesc} = {};
-  public static userSelectedUnaggregatedVisses: {[id: string]: IVisPluginDesc} = {};
-  public static multiformAggregationType: {[id: string]: any} = {};
+  public static userSelectedAggregatedVisses: {[id : string]: IVisPluginDesc} = {};
+  public static userSelectedUnaggregatedVisses: {[id : string]: IVisPluginDesc} = {};
+  public static multiformAggregationType: {[id : string]: any} = {};
 
   public static aggregationType = {
-    AGGREGATED: 1,
-    UNAGGREGATED: 2,
+    AGGREGATED : 1,
+    UNAGGREGATED : 2,
   };
 
   constructor() {
@@ -143,14 +143,14 @@ export default class VisManager {
       'phovea-vis-histogram': this.histogramOptions,
       'phovea-vis-mosaic': this.mosaicOptions,
       'phovea-vis-box': this.boxplotOptions,
-      'proportionalSymbol': this.propSymbolOptions
+      'proportionalSymbol' : this.propSymbolOptions
     };
   }
 
-  static getDefaultVis(columnType: string, dataType: string, aggregationType) {
-    switch (aggregationType) {
+  static getDefaultVis(columnType: string, dataType: string, aggregationType ) {
+    switch(aggregationType){
       case VisManager.aggregationType.AGGREGATED:
-        switch (columnType) {
+        switch(columnType){
           case 'vector':
             switch (dataType) {
               case VALUE_TYPE_STRING:
@@ -168,7 +168,7 @@ export default class VisManager {
             return 'list'
         }
       case VisManager.aggregationType.UNAGGREGATED:
-        switch (columnType) {
+        switch(columnType){
           case 'vector':
             switch (dataType) {
               case VALUE_TYPE_STRING:
@@ -188,10 +188,10 @@ export default class VisManager {
     }
   }
 
-  static getPossibleVisses(columnType: string, dataType: string, aggregationType) {
-    switch (aggregationType) {
+  static getPossibleVisses(columnType: string, dataType: string, aggregationType ) {
+    switch(aggregationType){
       case VisManager.aggregationType.AGGREGATED:
-        switch (columnType) {
+        switch(columnType){
           case 'vector':
             switch (dataType) {
               case VALUE_TYPE_STRING:
@@ -204,12 +204,12 @@ export default class VisManager {
                 return;
             }
           case 'matrix':
-            return VisManager.unaggregatedNumMatVisses;
+            return  VisManager.unaggregatedNumMatVisses;
           default:
             return
         }
       case VisManager.aggregationType.UNAGGREGATED:
-        switch (columnType) {
+        switch(columnType){
           case 'vector':
             switch (dataType) {
               case VALUE_TYPE_STRING:
@@ -222,35 +222,35 @@ export default class VisManager {
                 return;
             }
           case 'matrix':
-            return VisManager.unaggregatedNumMatVisses;
+            return  VisManager.unaggregatedNumMatVisses;
           default:
             return
         }
     }
   }
 
-  static setMultiformAggregationType(id: string, aggregationType) {
+  static setMultiformAggregationType(id:string, aggregationType){
     VisManager.multiformAggregationType[id] = aggregationType;
   }
 
-  static setUserVis(id: number, vis: IVisPluginDesc, aggregationType) {
-    if (aggregationType == VisManager.aggregationType.AGGREGATED) {
+  static setUserVis(id:number, vis:IVisPluginDesc, aggregationType) {
+    if(aggregationType == VisManager.aggregationType.AGGREGATED){
       VisManager.userSelectedAggregatedVisses[id] = vis;
-    } else {
+    }else{
       VisManager.userSelectedUnaggregatedVisses[id] = vis;
     }
   }
 
-  static updateUserVis(idOld: string, idNew: string) {
-    if (idOld in VisManager.userSelectedAggregatedVisses) {
+  static updateUserVis(idOld:string, idNew:string) {
+    if(idOld in VisManager.userSelectedAggregatedVisses) {
       VisManager.userSelectedAggregatedVisses[idNew] = VisManager.userSelectedAggregatedVisses[idOld];
     }
-    if (idOld in VisManager.userSelectedUnaggregatedVisses) {
+    if(idOld in VisManager.userSelectedUnaggregatedVisses) {
       VisManager.userSelectedUnaggregatedVisses[idNew] = VisManager.userSelectedUnaggregatedVisses[idOld];
     }
   }
 
-  static removeUserVisses(id: string) {
+  static removeUserVisses(id:string) {
     delete VisManager.userSelectedAggregatedVisses[id];
     delete VisManager.userSelectedUnaggregatedVisses[id];
   }
@@ -264,13 +264,13 @@ export default class VisManager {
     let minColumnHeight: number[] = [];
     col.multiformList.forEach((multiform, index) => {
       let minHeight;
-      if (multiform.id in VisManager.userSelectedAggregatedVisses
+      if(multiform.id in VisManager.userSelectedAggregatedVisses
         && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedAggregatedVisses[multiform.id].id, multiform.data.dim)[1];
-      } else if (multiform.id in VisManager.userSelectedUnaggregatedVisses
+      }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
         && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedUnaggregatedVisses[multiform.id].id, multiform.data.dim)[1];
-      } else {
+      }else{
         minHeight = Number.POSITIVE_INFINITY;
         let visses = VisManager.getPossibleVisses(multiform.data.desc.type, multiform.data.desc.value.type, VisManager.multiformAggregationType[multiform.id]);
         visses.forEach((v) => {
@@ -334,14 +334,14 @@ export default class VisManager {
 
 
   assignVis(multiform: MultiForm, width: number, height: number) {
-    if (multiform.id in VisManager.userSelectedAggregatedVisses
-      && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
+    if(multiform.id in VisManager.userSelectedAggregatedVisses
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
       multiform.switchTo(VisManager.userSelectedAggregatedVisses[multiform.id]);
-    } else if (multiform.id in VisManager.userSelectedUnaggregatedVisses
-      && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
-      multiform.switchTo(VisManager.userSelectedUnaggregatedVisses[multiform.id]);
-    } else {
-      let preferredVis = VisManager.getDefaultVis(multiform.data.desc.type, multiform.data.desc.value.type, VisManager.multiformAggregationType[multiform.id]);
+    }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
+       multiform.switchTo(VisManager.userSelectedUnaggregatedVisses[multiform.id]);
+    }else{
+      let preferredVis = VisManager.getDefaultVis(multiform.data.desc.type, multiform.data.desc.value.type,VisManager.multiformAggregationType[multiform.id]);
       multiform.switchTo(preferredVis);
     }
   }

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -242,15 +242,12 @@ export default class VisManager {
     }
   }
 
-  static updateUserVis(idOld:string, idNew:string, aggregationType) {
-    if(aggregationType == VisManager.aggregationType.AGGREGATED){
-      if(idOld in VisManager.userSelectedAggregatedVisses) {
-        VisManager.userSelectedAggregatedVisses[idNew] = VisManager.userSelectedAggregatedVisses[idOld];
-      }
-    }else{
-      if(idOld in VisManager.userSelectedUnaggregatedVisses) {
-        VisManager.userSelectedUnaggregatedVisses[idNew] = VisManager.userSelectedUnaggregatedVisses[idOld];
-      }
+  static updateUserVis(idOld:string, idNew:string) {
+    if(idOld in VisManager.userSelectedAggregatedVisses) {
+      VisManager.userSelectedAggregatedVisses[idNew] = VisManager.userSelectedAggregatedVisses[idOld];
+    }
+    if(idOld in VisManager.userSelectedUnaggregatedVisses) {
+      VisManager.userSelectedUnaggregatedVisses[idNew] = VisManager.userSelectedUnaggregatedVisses[idOld];
     }
   }
 

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -235,7 +235,7 @@ export default class VisManager {
   }
 
   static setUserVis(id:number, vis:IVisPluginDesc, aggregationType) {
-    if(aggregationType == VisManager.aggregationType.AGGREGATED){
+    if(aggregationType === VisManager.aggregationType.AGGREGATED){
       VisManager.userSelectedAggregatedVisses[id] = vis;
     }else{
       VisManager.userSelectedUnaggregatedVisses[id] = vis;
@@ -266,10 +266,10 @@ export default class VisManager {
     col.multiformList.forEach((multiform, index) => {
       let minHeight;
       if(multiform.id in VisManager.userSelectedAggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.AGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedAggregatedVisses[multiform.id].id, multiform.data.dim)[1];
       }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.UNAGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
         minHeight = this.minVisSize(VisManager.userSelectedUnaggregatedVisses[multiform.id].id, multiform.data.dim)[1];
       }else{
         minHeight = Number.POSITIVE_INFINITY;
@@ -336,23 +336,14 @@ export default class VisManager {
 
   assignVis(multiform: MultiForm, width: number, height: number) {
     if(multiform.id in VisManager.userSelectedAggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.AGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.AGGREGATED) {
       multiform.switchTo(VisManager.userSelectedAggregatedVisses[multiform.id]);
     }else if(multiform.id in VisManager.userSelectedUnaggregatedVisses
-        && VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.UNAGGREGATED) {
+        && VisManager.multiformAggregationType[multiform.id] === VisManager.aggregationType.UNAGGREGATED) {
        multiform.switchTo(VisManager.userSelectedUnaggregatedVisses[multiform.id]);
     }else{
       let preferredVis = VisManager.getDefaultVis(multiform.data.desc.type, multiform.data.desc.value.type,VisManager.multiformAggregationType[multiform.id]);
       let minPreferredSize = this.minVisSize(preferredVis, multiform.data.dim);
-
-      if (!((minPreferredSize[1] <= height) && (minPreferredSize[0] <= width))) {
-        if(VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.AGGREGATED) {
-          //choose smaller agggreg vis
-        }
-        if(VisManager.multiformAggregationType[multiform.id] == VisManager.aggregationType.UNAGGREGATED) {
-          //choose smaller nonaggre vis vis
-        }
-      }
       multiform.switchTo(preferredVis);
     }
   }

--- a/src/column/VisManager.ts
+++ b/src/column/VisManager.ts
@@ -107,7 +107,7 @@ export default class VisManager {
   /**
    *User selected visualization for multiform with given id
    */
-  public userSelectedVisses: {[id : number] : IVisPluginDesc} = {};
+  public static userSelectedVisses: {[id : number] : IVisPluginDesc} = {};
 
   constructor(){
     this.vissesOptions = {
@@ -122,7 +122,7 @@ export default class VisManager {
     };
   }
 
-  static getDefaultVis(columnType: string, dataType: string){
+  static getDefaultVis(columnType: string, dataType: string) {
     switch(columnType){
       case 'vector':
         switch(dataType) {
@@ -142,6 +142,14 @@ export default class VisManager {
     }
   }
 
+  static setUserVis(id:number, vis:IVisPluginDesc) {
+      VisManager.userSelectedVisses[id] = vis;
+  }
+
+  static updateUserVis(idOld:number, idNew:number) {
+      VisManager.userSelectedVisses[idNew] = VisManager.userSelectedVisses[idOld];
+  }
+
   /*
    * Compute minimum height of column depending on
    * minimal size of user-selced visualizations and
@@ -151,8 +159,8 @@ export default class VisManager {
     let minColumnHeight : number[] = [];
     col.multiformList.forEach((multiform, index)=>{
       let minHeight;
-      if(multiform.id in this.userSelectedVisses){
-       minHeight = this.minVisSize(this.userSelectedVisses[multiform.id].id, multiform.data.dim)[1];
+      if(multiform.id in VisManager.userSelectedVisses){
+       minHeight = this.minVisSize(VisManager.userSelectedVisses[multiform.id].id, multiform.data.dim)[1];
       }else{
         minHeight = Number.POSITIVE_INFINITY;
         const visses:IVisPluginDesc[] = multiform.visses;
@@ -215,8 +223,8 @@ export default class VisManager {
 
   assignVis(multiform: MultiForm, width: number, height: number) {
     const visses:IVisPluginDesc[] = multiform.visses;
-    if(multiform.id in this.userSelectedVisses){
-      multiform.switchTo(this.userSelectedVisses[multiform.id]);
+    if(multiform.id in VisManager.userSelectedVisses){
+      multiform.switchTo(VisManager.userSelectedVisses[multiform.id]);
       //TODO Scale to required size
     }else{
       const preferredVis = VisManager.getDefaultVis(multiform.data.desc.type, multiform.data.desc.value.type);


### PR DESCRIPTION
Functionality for switching aggregation and unaggregation visualizations per column
Adresses these issues:
https://github.com/Caleydo/mothertable/issues/56
https://github.com/Caleydo/mothertable/issues/210
https://github.com/Caleydo/mothertable/issues/222

Right now only visualizations that work well are added. @thinkh  you can test this best if you add some stratifying columns and than numerical (which has more options for visualizations) and play with switching visualizations and filtering data (so the view switches between aggreg. to unagregg.)