### PR TITLE
Fix matrix exceptions (#264)

### DIFF
--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -41,7 +41,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   dataView: IDataType;
   sortCriteria: string = SORT.asc;
   rangeView: Range;
-  multiformList = [];
+  multiformList:TaggleMultiform[] = [];
 
   selectedAggVis: IVisPluginDesc;
   selectedUnaggVis: IVisPluginDesc;
@@ -192,8 +192,9 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   }
 
 
-  async updateMultiForms(multiformRanges: Range[], stratifiedRanges?: Range[], brushedRanges?: Range[]) {
+  async updateMultiForms(multiformRanges: Range[], stratifiedRanges?: Range[], brushedRanges?: Range[]):Promise<TaggleMultiform[]> {
     // hook
+    return Promise.resolve(this.multiformList);
   }
 
   protected findGroupId(stratifiedRanges: Range[], multiformRange: Range) {

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -79,24 +79,19 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
   async updateMultiForms(multiformRanges: Range[], stratifiedRanges?: Range[], brushedRanges?: Range[]) {
     const v: any = await this.data.data(); // wait first for data and then continue with removing old forms
     const domain = d3.extent(v);
+
     const viewPromises = multiformRanges.map((r) => this.data.idView(r));
-    Promise.all(viewPromises).then((views) => {
+
+    return Promise.all(viewPromises).then((views) => {
       this.updateSortIcon();
 
       this.body.selectAll('.multiformList').remove();
       this.multiformList = [];
 
       views.forEach((view, id) => {
-        const $multiformdivs = this.body.append('div').classed('multiformList', true);
-        const $header = $multiformdivs.append('div').classed('vislist', true);
-        this.body.selectAll('.multiformList')
-          .on('mouseover', function () {
-            d3.select(this).select('.vislist').style('display', 'block');
-          })
-          .on('mouseleave', function () {
-            d3.select(this).select('.vislist').style('display', 'none');
-          });
-        const m = new TaggleMultiform(view, <HTMLElement>$multiformdivs.node(), this.multiFormParams($multiformdivs, domain));
+        const $multiformDivs = this.body.append('div').classed('multiformList', true);
+
+        const m = new TaggleMultiform(view, <HTMLElement>$multiformDivs.node(), this.multiFormParams($multiformDivs, domain));
         m.groupId = this.findGroupId(stratifiedRanges, multiformRanges[id]);
         m.brushed = this.checkBrushed(brushedRanges, multiformRanges[id]);
 
@@ -108,8 +103,11 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
           VisManager.userSelectedUnaggregatedVisses.set(m.id, this.selectedUnaggVis);
         }
         VisManager.multiformAggregationType.set(m.id, EAggregationType.UNAGGREGATED);
+
         this.multiformList.push(m);
       });
+
+      return this.multiformList;
     });
   }
 

--- a/src/column/CategoricalColumn.ts
+++ b/src/column/CategoricalColumn.ts
@@ -42,12 +42,15 @@ export default class CategoricalColumn extends AVectorColumn<string, ICategorica
       .attr('title', 'Stratify table by this column')
       .html(`<i class="fa fa-columns fa-rotate-270 fa-fw" aria-hidden="true"></i><span class="sr-only">Stratify table by this column</span>`)
       .on('click', () => {
-        this.fire(CategoricalColumn.EVENT_STRATIFYME, this); // for stratifying in the ColumnManager
         fire(CategoricalColumn.EVENT_STRATIFYME, this); // for updating the filter and other columns
       });
 
     on(CategoricalColumn.EVENT_STRATIFYME, (evt, ref) => {
       $stratifyButton.classed('active', ref.data.desc.id === this.data.desc.id);
+
+      if(ref.data.desc.id === this.data.desc.id) {
+        this.fire(CategoricalColumn.EVENT_STRATIFYME, this); // for stratifying in the ColumnManager
+      }
     });
   }
 

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -43,6 +43,7 @@ import {AnyFilter} from '../filter/AFilter';
 import AggSwitcherColumn from './AggSwitcherColumn';
 import {EAggregationType} from './VisManager';
 import {List} from 'phovea_vis/src/list';
+import TaggleMultiform from './TaggleMultiform';
 
 export declare type AnyColumn = AColumn<any, IDataType>;
 export declare type IMotherTableType = IStringVector|ICategoricalVector|INumericalVector|INumericalMatrix;
@@ -301,18 +302,13 @@ export default class ColumnManager extends EventHandler {
     }
 
     await this.updateStratifyID(this.stratifyColid);
-    if (this.totalbrushed.length === 0) {
-      await this.stratifyColumns();
-      this.updateAggModePerGroupAfterNewStrat(oldRanges);
-      this.relayout();
-      return;
+
+    if (this.totalbrushed.length > 0) {
+      await this.updateRangeList(this.brushedItems);
     }
 
-    await this.updateRangeList(this.brushedItems);
     await this.stratifyColumns();
     this.updateAggModePerGroupAfterNewStrat(oldRanges);
-
-
     this.relayout();
   }
 
@@ -393,10 +389,9 @@ export default class ColumnManager extends EventHandler {
 
   /**
    *
-   * @param idRange
-   * @returns {Promise<void>}
+   * @returns {Promise<[TaggleMultiform[][],TaggleMultiform[][],TaggleMultiform[]]>}
    */
-  private async stratifyColumns() {
+  private stratifyColumns() {
     let brushedRages = [];
     const r = this._multiformRangeList;
     if (VisManager.modePerGroup.length === this._stratifiedRanges.length && this._brushedRanges.length > 0) {
@@ -425,19 +420,19 @@ export default class ColumnManager extends EventHandler {
     this._multiformRangeList = brushedRages;
 
     const vectorCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.vector);
-    vectorCols.forEach((col) => {
-      col.updateMultiForms(brushedRages, this._stratifiedRanges, this._brushedRanges);
-    });
+    const vectorUpdatePromise = Promise.all(vectorCols.map((col) => col.updateMultiForms(brushedRages, this._stratifiedRanges, this._brushedRanges)));
+
     // update matrix column with last sorted range
     const matrixCols = this.columns.filter((col) => col.data.desc.type === AColumn.DATATYPE.matrix);
-    matrixCols.map((col) => col.updateMultiForms(this._multiformRangeList, this._stratifiedRanges, this._brushedRanges));
-
+    const matrixUpdatePromise = Promise.all(matrixCols.map((col) => col.updateMultiForms(this._multiformRangeList, this._stratifiedRanges, this._brushedRanges)));
 
     // update aggregation switcher column
     this.aggSwitcherCol.updateMultiForms(this.stratifiedRanges);
 
     //update the stratifyIcon
     this.updateStratifyIcon(findColumnTie(this.filtersHierarchy));
+
+    return Promise.all([vectorUpdatePromise, matrixUpdatePromise]);
   }
 
   private updateStratifyIcon(columnIndexForTie: number) {


### PR DESCRIPTION
Adding a matrix now works as expected and therefore fixes #264.

The problem arised with "concurrent execution" and wrong usage of `async`/`await`. In the future please think twice if you use `await` if something runs in the mean time (and if yes, what).